### PR TITLE
Add license header, VSCode snippets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,19 @@
+# Copyright 2019 Adam Chalkley
+#
+# https://github.com/atc0005/elbow
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 *.test
 testing/
 *.exe

--- a/.vscode/snippets-templates.code-snippets
+++ b/.vscode/snippets-templates.code-snippets
@@ -1,0 +1,57 @@
+// Copyright 2019 Adam Chalkley
+//
+// https://github.com/atc0005/elbow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+{
+	"GitHub repo link": {
+		"scope": "",
+		"prefix": "GitHub",
+		"body": [
+			"https://github.com/atc0005/elbow",
+		],
+		"description": "Add GitHub repo reference"
+	},
+	"Modelines Template": {
+		"scope": "",
+		"prefix": "Modelines",
+		"body": [
+			"# vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab tw=72",
+			"# -*- mode: go; indent-tabs-mode: t; tab-width: 4 -*-",
+			"# code: language=go insertSpaces=false tabSize=4"
+		],
+		"description": "Add common Modelines entry"
+	},
+	"License header": {
+		"scope": "",
+		"prefix": "license",
+		"body": [
+			"// Copyright 2019 Adam Chalkley",
+			"//",
+			"// https://github.com/atc0005/elbow",
+			"//",
+			"// Licensed under the Apache License, Version 2.0 (the \"License\");",
+			"// you may not use this file except in compliance with the License.",
+			"// You may obtain a copy of the License at",
+			"//",
+			"//     https://www.apache.org/licenses/LICENSE-2.0",
+			"//",
+			"// Unless required by applicable law or agreed to in writing, software",
+			"// distributed under the License is distributed on an \"AS IS\" BASIS,",
+			"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+			"// See the License for the specific language governing permissions and",
+			"// limitations under the License."
+		],
+		"description": "Add Apache License 2.0 compliant header"
+	},
+}

--- a/config.go
+++ b/config.go
@@ -1,3 +1,19 @@
+// Copyright 2019 Adam Chalkley
+//
+// https://github.com/atc0005/elbow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,21 @@
 module github.com/atc0005/elbow
 
+// Copyright 2019 Adam Chalkley
+//
+// https://github.com/atc0005/elbow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 go 1.12
 
 require (

--- a/logging.go
+++ b/logging.go
@@ -1,3 +1,19 @@
+// Copyright 2019 Adam Chalkley
+//
+// https://github.com/atc0005/elbow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/logging_unix.go
+++ b/logging_unix.go
@@ -1,5 +1,21 @@
 // +build !windows
 
+// Copyright 2019 Adam Chalkley
+//
+// https://github.com/atc0005/elbow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/logging_windows.go
+++ b/logging_windows.go
@@ -1,5 +1,21 @@
 // +build windows
 
+// Copyright 2019 Adam Chalkley
+//
+// https://github.com/atc0005/elbow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,19 @@
+// Copyright 2019 Adam Chalkley
+//
+// https://github.com/atc0005/elbow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/main_test.go
+++ b/main_test.go
@@ -1,3 +1,19 @@
+// Copyright 2019 Adam Chalkley
+//
+// https://github.com/atc0005/elbow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import "testing"

--- a/matches.go
+++ b/matches.go
@@ -1,3 +1,19 @@
+// Copyright 2019 Adam Chalkley
+//
+// https://github.com/atc0005/elbow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/paths.go
+++ b/paths.go
@@ -1,3 +1,19 @@
+// Copyright 2019 Adam Chalkley
+//
+// https://github.com/atc0005/elbow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (


### PR DESCRIPTION
- Add Apache License 2.0 header to the top of each source file
- Add VSCode snippets (including one for inserting a license)
  for future quick reference

fixes #17