### PR TITLE
Remove duplicate log text

### DIFF
--- a/paths.go
+++ b/paths.go
@@ -68,7 +68,7 @@ func cleanPath(files FileMatches, config *Config) (PathPruningResults, error) {
 		log.WithFields(logrus.Fields{
 			"removal_enabled": config.Remove,
 			"file":            filename,
-		}).Info("Removing file", filename)
+		}).Info("Removing file")
 
 		err := os.Remove(filename)
 		if err != nil {


### PR DESCRIPTION
The structured logging field has the same text already in the main log message.