### PR TITLE
Allow custom test files location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
+## [v0.3.1] - 2019-09-29
+
+### Changed
+
+- Update `Makefile` (and the called `testing/setup_testenv.sh` script) to allow
+  for providing a custom location for generation of test files)
+
+### Fixed
+
+- Minor tweak to logging output to reduce duplication between main log message
+  and the structured field
+
 ## [v0.3.0] - 2019-09-27
 
 ### Added
@@ -112,7 +124,8 @@ This initial prototype supports:
 - Go modules (vs classic GOPATH setup)
 - Brief overview, examples for testing purposes
 
-[Unreleased]: https://github.com/atc0005/elbow/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/atc0005/elbow/compare/v0.3.1...HEAD
+[v0.3.1]: https://github.com/atc0005/elbow/releases/tag/v0.3.1
 [v0.3.0]: https://github.com/atc0005/elbow/releases/tag/v0.3.0
 [v0.2.0]: https://github.com/atc0005/elbow/releases/tag/v0.2.0
 [v0.1.0]: https://github.com/atc0005/elbow/releases/tag/v0.1.0

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@
 
 
 OUTPUTBASEFILENAME		= elbow
+TESTENVDIR				= /tmp
 
 # The default `go build` process embeds debugging information. Building
 # without that debugging information reduces the binary size by around 28%.
@@ -54,9 +55,9 @@ help:
 	@echo "  testenv        setup test environment in Windows Subsystem for Linux or other Linux system"
 
 testenv:
-	@echo "Setting up test environment"
-	@bash testing/setup_testenv.sh "/tmp"
-	@echo "Finished creating test files"
+	@echo "Setting up test environment in \"$(TESTENVDIR)\""
+	@bash testing/setup_testenv.sh "$(TESTENVDIR)"
+	@echo "Finished creating test files in \"$(TESTENVDIR)\""
 
 goclean:
 	@echo "Removing object files and cached files ..."

--- a/README.md
+++ b/README.md
@@ -115,7 +115,13 @@ Tested using:
    1. `cd /tmp`
    1. `git clone https://github.com/atc0005/elbow`
    1. `cd elbow`
-1. `make testenv`
+1. Create test files
+   - in `/tmp`
+     - `make testenv`
+     - Note: `/tmp` is the default location
+   - in a custom location (e.g., in `$HOME/tmp`)
+     - `mkdir -vp $HOME/tmp`
+     - `make testenv TESTENVDIR=$HOME/tmp`
 
 See the [Examples](#examples) or the [Configuration
 Options](#configuration-options) sections for examples of running `elbow`

--- a/testing/setup_testenv.sh
+++ b/testing/setup_testenv.sh
@@ -20,7 +20,12 @@ TEST_DIR_PATH=$1
 
 PATH_TO_THIS_SCRIPT="$(dirname $(echo $0))"
 
+if [[ ! -d "$TEST_DIR_PATH" ]]; then
+    echo "\"$TEST_DIR_PATH\" not found! Please create and then re-run make command."
+    exit 1
+fi
+
 while read line
 do
-    touch -d $(echo $line | awk -F\- '{print $4}') /tmp/${line}
+    touch -d $(echo $line | awk -F\- '{print $4}') ${TEST_DIR_PATH}/${line}
 done < ${PATH_TO_THIS_SCRIPT}/sample_files_list_dev_web_app_server.txt


### PR DESCRIPTION
- Update `Makefile` (and the called `testing/setup_testenv.sh` script) to allow
  for providing a custom location for generation of test files)
- Update README to illustrate how to override the default testenv location
- Update CHANGELOG to cover recent work towards v0.3.1 release

fixes #29 