### PR TITLE
Fix various spelling errors

### DIFF
--- a/config.go
+++ b/config.go
@@ -49,7 +49,7 @@ type Config struct {
 	LogFileHandle   *os.File `no-flag:"true"`
 	ConsoleOutput   string   `long:"console-output" choice:"stdout" choice:"stderr" default:"stdout" description:"Specify how log messages are logged to the console."`
 	LogLevel        string   `long:"log-level" choice:"emergency" choice:"alert" choice:"critical" choice:"panic" choice:"fatal" choice:"error" choice:"warn" choice:"info" choice:"notice" choice:"debug" choice:"trace" default:"info" description:"Maximum log level at which messages will be logged. Log messages below this threshold will be discarded."`
-	UseSyslog       bool     `long:"use-syslog" description:"Log messages to syslog in addition to other ouputs. Not supported on Windows."`
+	UseSyslog       bool     `long:"use-syslog" description:"Log messages to syslog in addition to other outputs. Not supported on Windows."`
 }
 
 // NewConfig returns a new Config pointer that can be chained with builder
@@ -132,7 +132,7 @@ func (c *Config) SetupFlags(appName string, appDesc string) *Config {
 
 }
 
-// Validate verifies all struct fields have been provided accceptable
+// Validate verifies all struct fields have been provided acceptable
 func (c *Config) Validate() bool {
 
 	// FilePattern is optional

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 	appName := "Elbow"
 	appDesc := "Prune content matching specific patterns, either in a single directory or recursively through a directory tree."
 
-	log.Debug("Contructing config object")
+	log.Debug("Constructing config object")
 
 	// If this fails, the application will immediately exit.
 	config := NewConfig().SetupFlags(appName, appDesc)

--- a/paths.go
+++ b/paths.go
@@ -124,7 +124,7 @@ func processPath(config *Config) (FileMatches, error) {
 	var err error
 
 	log.WithFields(logrus.Fields{
-		"resursive_search": config.RecursiveSearch,
+		"recursive_search": config.RecursiveSearch,
 	}).Debugf("Recursive search: %t", config.RecursiveSearch)
 
 	if config.RecursiveSearch {


### PR DESCRIPTION
Credit goes to VSCode's Code Spell Checker extension for catching them.