### PR TITLE
Log config field values after setting logging lvl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The following types of changes will be recorded in this file:
 ### Fixed
 
 - Update `String()` method to include new fields
+- Log config field values after setting logging level so that they're visible
+  when choosing to log at `debug` level
 
 ## [v0.3.1] - 2019-09-29
 

--- a/main.go
+++ b/main.go
@@ -43,15 +43,6 @@ func main() {
 
 	log.Debug("Config object created")
 
-	defaultConfig := NewConfig()
-	log.WithFields(logrus.Fields{
-		"defaultConfig": defaultConfig,
-	}).Debug("Default configuration")
-
-	log.WithFields(logrus.Fields{
-		"config": config,
-	}).Debug("Our configuration")
-
 	// Validate configuration
 	// TODO: How much of this work does go-flags handle for us?
 	// TODO: Best practice to return an `error` here, even if it is nil?
@@ -65,6 +56,15 @@ func main() {
 	// Apply our custom logging settings on top of the existing global `log`
 	// object (which uses default settings)
 	setLoggerConfig(config, log)
+
+	defaultConfig := NewConfig()
+	log.WithFields(logrus.Fields{
+		"defaultConfig": defaultConfig,
+	}).Debug("Default configuration")
+
+	log.WithFields(logrus.Fields{
+		"config": config,
+	}).Debug("Our configuration")
 
 	// https://www.joeshaw.org/dont-defer-close-on-writable-files/
 	if config.LogFileHandle != nil {


### PR DESCRIPTION
The previous setup logged the config field values before the logging level was (potentially) adjusted via command-line parameter. This resulted in those log statements being filtered out due to the default INFO logging level.

fixes #40