### PR TITLE
Remove placeholder text from README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The following types of changes will be recorded in this file:
 - Update `String()` method to include new fields
 - Log config field values after setting logging level so that they're visible
   when choosing to log at `debug` level
+- Remove placeholder text from README file that has since been superseded by
+  real content
 
 ## [v0.3.1] - 2019-09-29
 

--- a/README.md
+++ b/README.md
@@ -143,10 +143,6 @@ against these newly created test files.
 
 ## Configuration Options
 
-Placeholder. Add table of all command-line flags here with a very brief
-explanation of what they're used for and whether they're required (should be
-listed first) or optional (listed last).
-
 ### Command-line Arguments
 
 Aside from the built-in `-h`, short flag names are currently not supported.


### PR DESCRIPTION
- The placeholder text has log since been superseded by real content
- Update CHANGELOG file

fixes #43