### PR TITLE
Fix cleanPath() function by using full file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ The following types of changes will be recorded in this file:
   when choosing to log at `debug` level
 - Remove placeholder text from README file that has since been superseded by
   real content
+- Fix file removal bug by using fully-qualified path to file instead of
+  shortname
+  - the bug was due to an unintentional assumption that the file to be removed
+    was within the current working directory
 
 ## [v0.3.1] - 2019-09-29
 

--- a/paths.go
+++ b/paths.go
@@ -63,16 +63,21 @@ func cleanPath(files FileMatches, config *Config) (PathPruningResults, error) {
 
 	for _, file := range files {
 
-		filename := file.Name()
-
 		log.WithFields(logrus.Fields{
 			"removal_enabled": config.Remove,
-			"file":            filename,
+
+			// fully-qualified path to the file
+			"file": file.Path,
 		}).Info("Removing file")
 
-		err := os.Remove(filename)
+		// We need to reference the full path here, not the short name since
+		// the current working directory may not be the same directory
+		// where the file is located
+		err := os.Remove(file.Path)
 		if err != nil {
 			log.WithFields(logrus.Fields{
+
+				// Include full details for troubleshooting purposes
 				"file": file,
 			}).Errorf("Error encountered while removing file: %s", err)
 


### PR DESCRIPTION
Fix file removal bug by using fully-qualified path to file instead of shortname. The bug was due to an
unintentional assumption that the file to be removed was within the current working directory.

fixes #43