### PR TITLE
Add environment variables support, switch flags package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,15 +24,37 @@ The following types of changes will be recorded in this file:
 
 ## [Unreleased]
 
+- placeholder
+
+## [v0.4.0] - 2019-10-17 (PENDING)
+
+### Added
+
+- Support for environment variables via `alexflint/go-arg` package
+- `Makefile` command: `testrun`
+
 ### Changed
 
+- `--extension` (multi-use) flag is now `--extensions` (single call, multiple values supported
+  - See [README](README.md) for usage
+- Replaced `jessevdk/go-flags` package with `alexflint/go-arg`
+- Improve configuration validation to accommodate lack of native `go-arg`
+  support for enforcing specific flag values
+- `Makefile`
+  - TODO: Add more info here
 - `go.mod` updated to use Go 1.13 as the base version
-  - Based on some reading in <https://github.com/golang/go/wiki/Modules,> the
+  - Based on some reading in <https://github.com/golang/go/wiki/Modules>, the
     behavior for `go get -u` changed to allow more conservative updates of
     dependencies. The new behavior sounds more natural and is less likely to
     surprise newcomers, so locking the base behavior to Go 1.13 sounds like a
     "Good Thing" to do here.
 - README updated to note Go 1.13 as the base version
+
+### Removed
+
+- `jessevdk/go-flags` package replaced with `alexflint/go-arg`
+
+### Fixed
 
 ## [v0.3.2] - 2019-10-16
 
@@ -149,7 +171,8 @@ This initial prototype supports:
 - Go modules (vs classic GOPATH setup)
 - Brief overview, examples for testing purposes
 
-[Unreleased]: https://github.com/atc0005/elbow/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/atc0005/elbow/compare/v0.4.0...HEAD
+[v0.4.0]: https://github.com/atc0005/elbow/releases/tag/v0.4.0
 [v0.3.2]: https://github.com/atc0005/elbow/releases/tag/v0.3.2
 [v0.3.1]: https://github.com/atc0005/elbow/releases/tag/v0.3.1
 [v0.3.0]: https://github.com/atc0005/elbow/releases/tag/v0.3.0

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ BUILDCMD				=	go build -a -ldflags="-s -w"
 BINARYPACKCMD			=	upx -f --brute
 GOCLEANCMD				=	go clean
 GITCLEANCMD				= 	git clean -xfd
+TESTENVCMD				=   bash testing/setup_testenv.sh
+TESTRUNCMD				=   bash testing/run_with_test_settings.sh
 
 .DEFAULT_GOAL := help
 
@@ -53,11 +55,17 @@ help:
 	@echo "  windows        to generate a binary file for Windows"
 	@echo "  linux          to generate a binary file for Linux distros"
 	@echo "  testenv        setup test environment in Windows Subsystem for Linux or other Linux system"
+	@echo "  testrun        use wrapper script to call binary with test settings"
 
 testenv:
 	@echo "Setting up test environment in \"$(TESTENVDIR)\""
-	@bash testing/setup_testenv.sh "$(TESTENVDIR)"
+	@$(TESTENVCMD) "$(TESTENVDIR)"
 	@echo "Finished creating test files in \"$(TESTENVDIR)\""
+
+testrun:
+	@echo "Calling wrapper script: $(TESTRUNCMD)"
+	@$(TESTRUNCMD) "$(OUTPUTBASEFILENAME)" "$(TESTENVDIR)"
+	@echo "Finished running wrapper script"
 
 goclean:
 	@echo "Removing object files and cached files ..."

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -16,6 +16,36 @@ specific language governing permissions and limitations under the License.
 
 
 
+https://github.com/alexflint/go-arg/blob/master/LICENSE
+
+Copyright (c) 2015, Alex Flint
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+
+
 https://github.com/jessevdk/go-flags/blob/master/LICENSE
 
 Copyright (c) 2012 Jesse van den Kieboom. All rights reserved.

--- a/config.go
+++ b/config.go
@@ -19,129 +19,153 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
-	"github.com/jessevdk/go-flags"
+	"github.com/alexflint/go-arg"
 )
+
+// AppMetadata represents data about this application that may be used in Help
+// output, error messages and potentially log messages (e.g., AppVersion)
+type AppMetadata struct {
+	AppName        string `arg:"-"`
+	AppDescription string `arg:"-"`
+	AppVersion     string `arg:"-"`
+	AppURL         string `arg:"-"`
+}
+
+// FileHandlingOptions represents options specific to how this application
+// handles files.
+type FileHandlingOptions struct {
+	FilePattern    string   `arg:"--pattern,env:ELBOW_FILE_PATTERN" help:"Substring pattern to compare filenames against. Wildcards are not supported."`
+	FileExtensions []string `arg:"--extensions,env:ELBOW_EXTENSIONS" help:"Limit search to specified file extensions. Specify as space separated list to match multiple required extensions."`
+	FileAge        int      `arg:"--age,env:ELBOW_FILE_AGE" help:"Limit search to files that are the specified number of days old or older."`
+	NumFilesToKeep int      `arg:"--keep,env:ELBOW_KEEP" arg:"required" help:"Keep specified number of matching files."`
+	KeepOldest     bool     `arg:"--keep-old,env:ELBOW_KEEP_OLD" help:"Keep oldest files instead of newer."`
+	Remove         bool     `arg:"--remove,env:ELBOW_REMOVE" help:"Remove matched files."`
+	IgnoreErrors   bool     `arg:"--ignore-errors,env:ELBOW_IGNORE_ERRORS" help:"Ignore errors encountered during file removal."`
+}
+
+// SearchOptions represents options specific to controlling how this
+// application performs searches in the filesystem
+type SearchOptions struct {
+	StartPath       string `arg:"--path,env:ELBOW_PATH" arg:"required" help:"Path to process."`
+	RecursiveSearch bool   `arg:"--recurse,env:ELBOW_RECURSE" help:"Perform recursive search into subdirectories."`
+}
+
+// LoggingOptions represents options specific to how this application handles
+// logging.
+type LoggingOptions struct {
+
+	// https://godoc.org/github.com/sirupsen/logrus#Level
+	// https://github.com/sirupsen/logrus/blob/de736cf91b921d56253b4010270681d33fdf7cb5/logrus.go#L81
+	LogLevel      string `arg:"--log-level,env:ELBOW_LOG_LEVEL" help:"Maximum log level at which messages will be logged. Log messages below this threshold will be discarded."`
+	LogFormat     string `arg:"--log-format,env:ELBOW_LOG_FORMAT" help:"Log formatter used by logging package."`
+	LogFilePath   string `arg:"--log-file,env:ELBOW_LOG_FILE" help:"Optional log file used to hold logged messages. If set, log messages are not displayed on the console."`
+	ConsoleOutput string `arg:"--console-output,env:ELBOW_CONSOLE_OUTPUT" help:"Specify how log messages are logged to the console."`
+	UseSyslog     bool   `arg:"--use-syslog,env:ELBOW_USE_SYSLOG" help:"Log messages to syslog in addition to other outputs. Not supported on Windows."`
+}
 
 // Config represents a collection of configuration settings for this
 // application. Config is created as early as possible upon application
 // startup.
 type Config struct {
 
-	// https://godoc.org/github.com/sirupsen/logrus#Level
-	// https://github.com/sirupsen/logrus/blob/de736cf91b921d56253b4010270681d33fdf7cb5/logrus.go#L81
-	// https://github.com/jessevdk/go-flags#example
-	// https://godoc.org/github.com/jessevdk/go-flags#hdr-Available_field_tags
-	// https://github.com/jessevdk/go-flags/blob/master/examples/main.go
-	// https://github.com/jessevdk/go-flags/blob/master/examples/rm.go
+	// Embed other structs in an effort to better group related settings
+	AppMetadata
+	FileHandlingOptions
+	LoggingOptions
+	SearchOptions
 
-	FilePattern     string   `long:"pattern" description:"Substring pattern to compare filenames against. Wildcards are not supported."`
-	FileExtensions  []string `long:"extension" description:"Limit search to specified file extension. Specify as needed to match multiple required extensions."`
-	StartPath       string   `long:"path" required:"true" description:"Path to process."`
-	RecursiveSearch bool     `long:"recurse" description:"Perform recursive search into subdirectories."`
-	FileAge         int      `long:"age" description:"Limit search to files that are the specified number of days old or older."`
-	NumFilesToKeep  int      `long:"keep" required:"true" description:"Keep specified number of matching files."`
-	KeepOldest      bool     `long:"keep-old" description:"Keep oldest files instead of newer."`
-	Remove          bool     `long:"remove" description:"Remove matched files."`
-	IgnoreErrors    bool     `long:"ignore-errors" description:"Ignore errors encountered during file removal."`
-	LogFormat       string   `long:"log-format" choice:"text" choice:"json" default:"text" description:"Log formatter used by logging package."`
-	LogFilePath     string   `long:"log-file" description:"Optional log file used to hold logged messages. If set, log messages are not displayed on the console."`
-	LogFileHandle   *os.File `no-flag:"true"`
-	ConsoleOutput   string   `long:"console-output" choice:"stdout" choice:"stderr" default:"stdout" description:"Specify how log messages are logged to the console."`
-	LogLevel        string   `long:"log-level" choice:"emergency" choice:"alert" choice:"critical" choice:"panic" choice:"fatal" choice:"error" choice:"warn" choice:"info" choice:"notice" choice:"debug" choice:"trace" default:"info" description:"Maximum log level at which messages will be logged. Log messages below this threshold will be discarded."`
-	UseSyslog       bool     `long:"use-syslog" description:"Log messages to syslog in addition to other outputs. Not supported on Windows."`
+	// Embedded to allow for easier carrying of "handles" between functions
+	// TODO: Confirm that this is both needed and that it doesn't violate
+	// best practices.
+	LogFileHandle *os.File    `arg:"-"`
+	FlagParser    *arg.Parser `arg:"-"`
 }
 
-// NewConfig returns a new Config pointer that can be chained with builder
-// methods to set multiple configuration values inline without using pointers.
+// NewConfig returns a newly configured object representing a collection of
+// user-provided and default settings.
 func NewConfig() *Config {
 
+	// "bootstrapping" for this object is provided via struct tags
+	var config Config
+
 	// Explicitly initialize with intended defaults
-	// TODO: If we stay with go-flags (which applies defaults), is this
-	// set of defaults still needed?
-	return &Config{
-		StartPath:   "",
-		FilePattern: "",
-		// NOTE: This creates an empty slice (not nil since there is an
-		// underlying array of zero length) FileExtensions:  []string{},
-		//
-		// Leave at default value of nil slice instead by not providing a
-		// value here
-		// FileExtensions:  []string,
-		FileAge:         0,
-		NumFilesToKeep:  0,
-		RecursiveSearch: false,
-		KeepOldest:      false,
-		Remove:          false,
-		IgnoreErrors:    false,
-		LogFormat:       "text",
-		LogLevel:        "info",
-		LogFilePath:     "",
-		LogFileHandle:   nil,
-		ConsoleOutput:   "stdout",
-		UseSyslog:       false,
-	}
+	// TODO: Add defaults to `Config{}` once
+	// https://github.com/alexflint/go-arg/pull/91 lands.
+	config.StartPath = ""
+	config.FilePattern = ""
+
+	// NOTE: This creates an empty slice (not nil since there is an
+	// underlying array of zero length) FileExtensions:  []string{},
+	//
+	// Leave at default value of nil slice instead by not providing a
+	// value here
+	// config.FileExtensions = []string
+	config.FileAge = 0
+	config.NumFilesToKeep = 0
+	config.RecursiveSearch = false
+	config.KeepOldest = false
+	config.Remove = false
+	config.IgnoreErrors = false
+	config.LogFormat = "text"
+	config.LogLevel = "info"
+	config.LogFilePath = ""
+	config.LogFileHandle = nil
+	config.ConsoleOutput = "stdout"
+	config.UseSyslog = false
+
+	// TODO: Configure these values elsewhere?
+	config.AppName = "Elbow"
+	config.AppDescription = "prunes content matching specific patterns, either in a single directory or recursively through a directory tree."
+	config.AppURL = "https://github.com/atc0005/elbow"
+
+	// TODO: Set this value via programatic build tag, likely based off of
+	// the latest Git tag + a 'dev' suffix if on a branch, or sans suffix
+	// if we can confirm that we've checked out a tag directly.
+	config.AppVersion = "x.y.z"
+
+	// Bundle the returned `*.arg.Parser` for later use from `main()` so that
+	// we can explicitly display usage or help details should the
+	// user-provided settings fail validation.
+	config.FlagParser = arg.MustParse(&config)
+
+	return &config
 
 }
 
-// SetupFlags applies settings provided by command-line flags
-// FIXME: go-flags doesn't use appName or appDesc. Keep?
-func (c *Config) SetupFlags(appName string, appDesc string) *Config {
+// Description provides an overview as part of the application Help output
+func (c Config) Description() string {
 
-	// RETURN HERE
-	// https://github.com/jessevdk/go-flags/blob/c0795c8afcf41dd1d786bebce68636c199b3bb45/flags.go#L172
-	// SETUP a new named parser with description and other details?
-	// this would allow grouping similar options together (log level, log file, syslog, etc)
+	return fmt.Sprintf("%s %s", c.AppName, c.AppDescription)
+}
 
-	// https://godoc.org/github.com/jessevdk/go-flags#NewParser
-	// https://godoc.org/github.com/jessevdk/go-flags#Options
-	// Default = HelpFlag | PrintErrors | PassDoubleDash
-	var parser = flags.NewParser(c, flags.Default)
-	//var parser = flags.NewNamedParser(appName, &c, flags.Default)
+// Version provides a version string that appears at the top of the
+// application Help output
+func (c Config) Version() string {
 
-	// TODO: What other handling is needed here? If the command-line arguments
-	// are not as expected, exiting the application should probably be the
-	// sensible next step?
-	if _, err := parser.Parse(); err != nil {
-		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
+	versionString := fmt.Sprintf("%s %s\n%s",
+		strings.ToTitle(c.AppName), c.AppVersion, c.AppURL)
 
-			// NOTE: This results in the Help output being shown twice.
-			//parser.WriteHelp(os.Stdout)
+	//divider := strings.Repeat("-", len(versionString))
 
-			os.Exit(0)
-		} else {
+	// versionBlock := fmt.Sprintf("\n%s\n%s\n%s\n",
+	// 	divider, versionString, divider)
 
-			// Another error was encountered. One case where we need to handle
-			// printing it to stdout or stderr ourselves is when setting
-			// `short:""` struct tags to greater than 1 character. In that
-			// case the `os.Exit(1)` call below is NOT preceded with a helpful
-			// message explaining the issue.
-			// fmt.Println(err)
-			//
-			// Once we can be sure WE configured the struct properly with
-			// valid length tags (or omitted the `short:""` tags), we can just
-			// use `os.Exit(1)` here to allow the application to exit after
-			// displaying the error code per our use of flags.Default when
-			// setting up the parser (`flags.Default` includes the PrintErrors
-			// option).
-			os.Exit(1)
-		}
-	}
+	//return versionBlock
 
-	return c
-
+	return "\n" + versionString + "\n"
 }
 
 // Validate verifies all struct fields have been provided acceptable
-func (c *Config) Validate() bool {
+func (c Config) Validate() (bool, error) {
 
 	// FilePattern is optional
-
 	// FileExtensions is optional
-	// Discovered files are checked against FileExtensions later
+	//   Discovered files are checked against FileExtensions later
 
 	if len(c.StartPath) == 0 {
-		return false
+		return false, fmt.Errorf("path not provided")
 	}
 
 	// RecursiveSearch is optional
@@ -150,7 +174,7 @@ func (c *Config) Validate() bool {
 	// a non-negative number. AFAIK, this is not currently enforced any other
 	// way.
 	if c.NumFilesToKeep < 0 {
-		return false
+		return false, fmt.Errorf("negative number not supported for files to keep")
 	}
 
 	// We only want to work with positive file modification times 0 is
@@ -158,38 +182,73 @@ func (c *Config) Validate() bool {
 	// not chosen to use the flag (or has chosen improperly and it will be
 	// ignored).
 	if c.FileAge < 0 {
-		return false
+		return false, fmt.Errorf("negative number for file age not supported")
 	}
 
 	// KeepOldest is optional
-
 	// Remove is optional
+	// IgnoreErrors is optional
 
-	// go-args `choice:""` struct tags enforce valid options
+	// go-flags `choice:""` struct tags enforce valid options
 	// if !inList(c.LogFormat, c.validLogFormats) {
 	// 	return false
 	// }
 
+	switch c.LogFormat {
+	case "text":
+	case "json":
+	default:
+		return false, fmt.Errorf("invalid option %q provided for log format", c.LogFormat)
+	}
+
 	// LogFilePath is optional
 	// TODO: String validation if it is set?
 
-	// go-args `choice:""` struct tags enforce valid options
+	// Do nothing for valid choices, return false if invalid value specified
+	switch c.ConsoleOutput {
+	case "stdout":
+	case "stderr":
+	default:
+		return false, fmt.Errorf("invalid option %q provided for console output destination", c.ConsoleOutput)
+	}
+
+	// go-flags `choice:""` struct tags enforce valid options
 	// if !inList(c.LogLevel, c.validLogLevels) {
 	// 	return false
 	// }
 
+	switch c.LogLevel {
+	case "emergency":
+	case "alert":
+	case "critical":
+	case "panic":
+	case "fatal":
+	case "error":
+	case "warn":
+	case "info":
+	case "notice":
+	case "debug":
+	case "trace":
+	default:
+		return false, fmt.Errorf("invalid option %q provided for log level", c.LogLevel)
+	}
+
 	// UseSyslog is optional
 
 	// Optimist
-	return true
+	return true, nil
 
 }
 
 // String() satisfies the Stringer{} interface. This is intended for non-JSON
 // formatting if using the TextFormatter logrus formatter.
 func (c *Config) String() string {
-	return fmt.Sprintf("FilePattern=%q, FileExtensions=%q, StartPath=%q, RecursiveSearch=%t, FileAge=%d, NumFilesToKeep=%d, KeepOldest=%t, Remove=%t, IgnoreErrors=%t, LogFormat=%q, LogFilePath=%q, LogFileHandle=%v, ConsoleOutput=%q, LogLevel=%q, UseSyslog=%t",
+	return fmt.Sprintf("AppName=%q, AppDescription=%q, AppVersion=%q, FilePattern=%q, FileExtensions=%q, StartPath=%q, RecursiveSearch=%t, FileAge=%d, NumFilesToKeep=%d, KeepOldest=%t, Remove=%t, IgnoreErrors=%t, LogFormat=%q, LogFilePath=%q, LogFileHandle=%v, ConsoleOutput=%q, LogLevel=%q, UseSyslog=%t",
 
+		// TODO: Finish syncing this against the config struct fields
+		c.AppName,
+		c.AppDescription,
+		c.AppVersion,
 		c.FilePattern,
 		c.FileExtensions,
 		c.StartPath,

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ module github.com/atc0005/elbow
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 // Based on some reading in https://github.com/golang/go/wiki/Modules, the
 // behavior for `go get -u` changed to allow more conservative updates of
 // dependencies. The new behavior sounds more natural and is less likely to
@@ -25,7 +24,7 @@ module github.com/atc0005/elbow
 go 1.13
 
 require (
-	github.com/jessevdk/go-flags v1.4.0
+	github.com/alexflint/go-arg v1.1.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,11 @@
+github.com/alexflint/go-arg v1.1.0 h1:92ADei0d3TP0mGBdJ/FNcF54X6uFY7BQfhqkrQt3CCE=
+github.com/alexflint/go-arg v1.1.0/go.mod h1:3Rj4baqzWaGGmZA2+bVTV8zQOZEjBQAPBnL5xLT+ftY=
+github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=
+github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
-github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/testing/run_with_test_settings.sh
+++ b/testing/run_with_test_settings.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Purpose: Small wrapper script to build and call binary with environment
+# variables already configured.
+
+
+# Copyright 2019 Adam Chalkley
+#
+# https://github.com/atc0005/elbow
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+BINARY_NAME="$1"
+WORK_PATH="$2"
+
+# Use default build options
+go build
+
+# See README for complete list of environment variables
+export ELBOW_PATH="${WORK_PATH}"
+export ELBOW_FILE_PATTERN="reach-masterdev-"
+export ELBOW_EXTENSIONS=".war,.tmp"
+export ELBOW_KEEP=1
+export ELBOW_FILE_AGE=1
+export ELBOW_RECURSE="true"
+export ELBOW_KEEP_OLD="true"
+export ELBOW_IGNORE_ERRORS="true"
+export ELBOW_LOG_LEVEL="lizard"
+export ELBOW_USE_SYSLOG="false"
+export ELBOW_LOG_FORMAT="json"
+export ELBOW_REMOVE="false"
+#export ELBOW_LOG_FILE="testing-masterqa-build-removals.txt"
+
+echo -e "\n\nCalling ${BINARY_NAME} without flags; rely on env vars\n"
+./${BINARY_NAME}
+
+if [[ $? -ne 0 ]]; then
+  echo "${BINARY_NAME} execution failed. See earlier output for details."
+  sleep 3
+fi
+
+# Test drive --extensions flag
+echo -e "\n\nCalling ${BINARY_NAME} with extensions flag specified\n"
+./${BINARY_NAME} \
+  --path /tmp \
+  --extensions ".war" ".tmp" \
+  --pattern "" \
+  --keep 1 \
+  --recurse \
+  --keep-old \
+  --ignore-errors \
+  --log-level info \
+  --use-syslog \
+  --log-format text \
+  --console-output "stdout"
+
+if [[ $? -ne 0 ]]; then
+  echo "${BINARY_NAME} execution failed. See earlier output for details."
+  sleep 3
+fi
+
+# Confirm that precedence works as expected
+echo -e "\n\nCalling ${BINARY_NAME} with flags; override env vars\n"
+./${BINARY_NAME} \
+  --path /tmp \
+  --keep 1 \
+  --recurse \
+  --keep-old \
+  --ignore-errors \
+  --log-level info \
+  --use-syslog \
+  --log-format text \
+  --console-output "stdout" \
+  --remove
+
+if [[ $? -ne 0 ]]; then
+  echo "${BINARY_NAME} execution failed. See earlier output for details."
+  sleep 3
+fi
+
+# Provide invalid option
+echo -e "\n\nCalling ${BINARY_NAME} with invalid flag"
+echo -e "This will result in several Makefile errors:\n"
+echo -e "    Makefile:66: recipe for target 'testrun' failed\n    make: *** [testrun] Error 1\n"
+#read -p "Press enter to continue"
+
+./${BINARY_NAME} \
+  --path /tmp \
+  --keep 1 \
+  --recurse \
+  --keep-old \
+  --ignore-errors \
+  --log-level info \
+  --use-syslog \
+  --log-format text \
+  --console-output "tacos"
+
+if [[ $? -ne 0 ]]; then
+  echo "${BINARY_NAME} execution failed. See earlier output for details."
+  sleep 3
+fi


### PR DESCRIPTION
## Added

- Support for environment variables via `alexflint/go-arg`
    package

- `Makefile` command: `testrun`
    - this command calls a wrapper script which uses common
    options in order to briefly test the app. I hope to
    replace this process with native `go test` compatible
    tests in the future

## Changed

- `--extension` (multi-use) flag is now `--extensions` (single call, multiple values supported)

- Replaced `jessevdk/go-flags` package with `alexflint/go-arg`

- Improve configuration validation to accommodate lack of native
    `go-arg` support for enforcing specific flag values

- `Makefile`
    - Minor cleanup for `testenv` command to be consistent with
    other make commands

- `go.mod`
    - `go mod tidy` used to prune old dependencies

- README
    - Add precedence information for config sources
    - updated to reflect new environment variables, including
    brief examples of usage

- NOTICE
    - Add license information for `alexflint/go-arg` file

- Logging
    - minor change to log file metadata used to determine
    removal eligibility

## Removed

- `jessevdk/go-flags` package replaced with `alexflint/go-arg`

---

fixes #3