### PR TITLE
Update go.mod, README to reflect Go 1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,15 @@ The following types of changes will be recorded in this file:
 
 ## [Unreleased]
 
-- placeholder
+### Changed
+
+- `go.mod` updated to use Go 1.13 as the base version
+  - Based on some reading in <https://github.com/golang/go/wiki/Modules,> the
+    behavior for `go get -u` changed to allow more conservative updates of
+    dependencies. The new behavior sounds more natural and is less likely to
+    surprise newcomers, so locking the base behavior to Go 1.13 sounds like a
+    "Good Thing" to do here.
+- README updated to note Go 1.13 as the base version
 
 ## [v0.3.2] - 2019-10-16
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ official release is also provided.
 
 ## Requirements
 
-- Go (for building)
-  - unsure what version; whatever the dependencies in `go.mod` require
+- Go 1.13+ (for building)
 - Linux (if using Syslog support)
   - macOS and UNIX systems have not been tested
 - GCC
@@ -91,7 +90,7 @@ official release is also provided.
 
 Tested using:
 
-- Go 1.12+
+- Go 1.13+
 - Windows 10 Version 1803+
 - Ubuntu Linux 16.04+
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,13 @@ module github.com/atc0005/elbow
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-go 1.12
+
+// Based on some reading in https://github.com/golang/go/wiki/Modules, the
+// behavior for `go get -u` changed to allow more conservative updates of
+// dependencies. The new behavior sounds more natural and is less likely to
+// surprise newcomers, so locking the base behavior to Go 1.13 sounds like a
+// "Good Thing" to do here.
+go 1.13
 
 require (
 	github.com/jessevdk/go-flags v1.4.0


### PR DESCRIPTION
- Change base Go version to 1.13 in `go.mod`
- Update README to reflect this
- Update CHANGELOG to note both changes

fixes #37 