### PR TITLE
Add missing age-based match options, fix doc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ would otherwise completely clog a filesystem.
 - Match on specified file patterns
 - Flat (single-level) or recursive search
 - Process one or many paths
+- Age-based threshold for matches (e.g., match files X days old or older)
 - Keep a specified number of older or newer matches
 - Limit search to specified list of file extensions
 - Toggle file removal (read-only by default)
@@ -166,6 +167,7 @@ Aside from the built-in `-h`, short flag names are currently not supported.
 | `extensions`     | No       | *empty list*   | No     | *valid file extensions*                                                                                 | Limit search to specified file extension. Specify as needed to match multiple required extensions.       |
 | `recurse`        | No       | `false`        | No     | `true`, `false`                                                                                         | Perform recursive search into subdirectories.                                                            |
 | `keep-old`       | No       | `false`        | No     | `true`, `false`                                                                                         | Keep oldest files instead of newer.                                                                      |
+| `age`            | No       | `0`            | No     | Limit search to files that are the specified number of days old or older.                               |
 | `remove`         | Maybe    | `false`        | No     | `true`, `false`                                                                                         | Remove matched files. The default behavior is to only note what matching files *would* be removed.       |
 | `ignore-errors`  | No       | `false`        | No     | `true`, `false`                                                                                         | Ignore errors encountered during file removal.                                                           |
 | `log-format`     | No       | `text`         | No     | `text`, `json`                                                                                          | Log formatter used by logging package.                                                                   |
@@ -188,6 +190,7 @@ for more information.
 | `extensions`     | `ELBOW_EXTENSIONS`        | *Comma-separated, no spaces* | `ELBOW_EXTENSIONS=".war,.tmp"`                                                      |
 | `recurse`        | `ELBOW_RECURSE`           |                              | `ELBOW_RECURSE="true"`                                                              |
 | `keep-old`       | `ELBOW_KEEP_OLD`          |                              | `ELBOW_KEEP_OLD="true"`                                                             |
+| `age`            | `ELBOW_FILE_AGE`          |                              | `ELBOW_FILE_AGE=120`                                                                |
 | `remove`         | `ELBOW_REMOVE`            |                              | `ELBOW_REMOVE="false"`                                                              |
 | `ignore-errors`  | `ELBOW_IGNORE_ERRORS`     |                              | `ELBOW_IGNORE_ERRORS="true"`                                                        |
 | `log-format`     | `ELBOW_LOG_FORMAT`        |                              | `ELBOW_LOG_FORMAT="json"`                                                           |

--- a/doc.go
+++ b/doc.go
@@ -34,6 +34,7 @@ FEATURES
 - Match on specified file patterns
 - Flat (single-level) or recursive search
 - Process one or many paths
+- Age-based threshold for matches (e.g., match files X days old or older)
 - Keep a specified number of older or newer matches
 - Limit search to specified list of file extensions
 - Toggle file removal (read-only by default)
@@ -46,35 +47,34 @@ FEATURES
 
 USAGE
 
-Elbow prunes content matching specific patterns, either in a single directory
-or recursively through a directory tree.
+Elbow prunes content matching specific patterns, either in a single directory or recursively through a directory tree.
 
-ELBOW x.y.z https://github.com/atc0005/elbow
+ELBOW x.y.z
+https://github.com/atc0005/elbow
 
-Usage: elbow [--pattern PATTERN] [--extensions EXTENSIONS] [--age AGE] [--keep
-KEEP] [--keep-old] [--remove] [--ignore-errors] [--log-level LOG-LEVEL]
-[--log-format LOG-FORMAT] [--log-file LOG-FILE] [--console-output
-CONSOLE-OUTPUT] [--use-syslog] [--paths PATHS] [--recurse]
+Usage: elbow [--pattern PATTERN] [--extensions EXTENSIONS] [--age AGE] [--keep KEEP] [--keep-old] [--remove] [--ignore-errors] [--log-level LOG-LEVEL] [--log-format LOG-FORMAT] [--log-file LOG-FILE] [--console-output CONSOLE-OUTPUT] [--use-syslog] [--paths PATHS] [--recurse]
 
-Options: --pattern PATTERN      Substring pattern to compare filenames
-  against. Wildcards are not supported. --extensions EXTENSIONS Limit search
-  to specified file extensions. Specify as space separated list to match
-  multiple required extensions. --age AGE              Limit search to files
-  that are the specified number of days old or older. --keep KEEP
-  Keep specified number of matching files per provided path. --keep-old
-  Keep oldest files instead of newer per provided path. --remove
-  Remove matched files per provided path. --ignore-errors        Ignore errors
-  encountered during file removal. --log-level LOG-LEVEL Maximum log level at
-  which messages will be logged. Log messages below this threshold will be
-  discarded. [default: info] --log-format LOG-FORMAT Log formatter used by
-  logging package. [default: text] --log-file LOG-FILE    Optional log file
-  used to hold logged messages. If set, log messages are not displayed on the
-  console. --console-output CONSOLE-OUTPUT Specify how log messages are logged
-  to the console. [default: stdout] --use-syslog           Log messages to
-  syslog in addition to other outputs. Not supported on Windows. --paths PATHS
-  List of comma or space-separated paths to process. --recurse
-  Perform recursive search into subdirectories per provided path. --help, -h
-  display this help and exit --version              display version and exit
+Options:
+  --pattern PATTERN      Substring pattern to compare filenames against. Wildcards are not supported.
+  --extensions EXTENSIONS
+                         Limit search to specified file extensions. Specify as space separated list to match multiple required extensions.
+  --age AGE              Limit search to files that are the specified number of days old or older.
+  --keep KEEP            Keep specified number of matching files per provided path.
+  --keep-old             Keep oldest files instead of newer per provided path.
+  --remove               Remove matched files per provided path.
+  --ignore-errors        Ignore errors encountered during file removal.
+  --log-level LOG-LEVEL
+                         Maximum log level at which messages will be logged. Log messages below this threshold will be discarded. [default: info]
+  --log-format LOG-FORMAT
+                         Log formatter used by logging package. [default: text]
+  --log-file LOG-FILE    Optional log file used to hold logged messages. If set, log messages are not displayed on the console.
+  --console-output CONSOLE-OUTPUT
+                         Specify how log messages are logged to the console. [default: stdout]
+  --use-syslog           Log messages to syslog in addition to other outputs. Not supported on Windows.
+  --paths PATHS          List of comma or space-separated paths to process.
+  --recurse              Perform recursive search into subdirectories per provided path.
+  --help, -h             display this help and exit
+  --version              display version and exit
 
 */
 


### PR DESCRIPTION
- Update README to provide coverage for missing `--age` and `ELBOW_FILE_AGE` options

- Update doc.go file to use intended line wrapping

fixes #71

refs, #66, #45