### PR TITLE
Add GoDoc badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Elbow, Elbow grease.
 
 [![Latest Release](https://img.shields.io/github/release/atc0005/elbow.svg?style=flat-square)](https://github.com/atc0005/elbow/releases/latest)
+[![GoDoc](https://godoc.org/github.com/atc0005/elbow?status.svg)](https://godoc.org/github.com/atc0005/elbow)
 
 - [elbow](#elbow)
   - [Project home](#project-home)


### PR DESCRIPTION
The GoDoc page doesn't currently have any coverage not included already in the README, but that is subject to change in the future.

fixes #44