### PR TITLE
Alter log level for "removing file" messages

### DIFF
--- a/paths.go
+++ b/paths.go
@@ -68,7 +68,7 @@ func cleanPath(files FileMatches, config *Config) (PathPruningResults, error) {
 
 			// fully-qualified path to the file
 			"file": file.Path,
-		}).Info("Removing file")
+		}).Debug("Removing file")
 
 		// We need to reference the full path here, not the short name since
 		// the current working directory may not be the same directory


### PR DESCRIPTION
Log messages are emitted BEFORE removing a file and again AFTER. Change log level of the BEFORE messages from INFO to DEBUG level in order to dedupe what is shown at INFO level.

fixes #80