### PR TITLE
Split main package into multiple subpackages

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"fmt"
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/alexflint/go-arg"
+	"github.com/sirupsen/logrus"
 )
 
 // AppMetadata represents data about this application that may be used in Help
@@ -79,8 +80,9 @@ type Config struct {
 	// Embedded to allow for easier carrying of "handles" between functions
 	// TODO: Confirm that this is both needed and that it doesn't violate
 	// best practices.
-	LogFileHandle *os.File    `arg:"-"`
-	FlagParser    *arg.Parser `arg:"-"`
+	LogFileHandle *os.File       `arg:"-"`
+	Logger        *logrus.Logger `arg:"-"`
+	FlagParser    *arg.Parser    `arg:"-"`
 }
 
 // NewConfig returns a newly configured object representing a collection of

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -14,16 +14,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package logging
 
 import (
 	"os"
 	"strings"
 
+	"github.com/atc0005/elbow/config"
+
 	"github.com/sirupsen/logrus"
 )
 
-func setLoggerConfig(config *Config, logger *logrus.Logger) {
+// SetLoggerConfig applies the requested logger configuration settings
+func SetLoggerConfig(config *config.Config) {
+
+	logger := config.Logger
 
 	switch config.LogFormat {
 	case "text":
@@ -54,7 +59,7 @@ func setLoggerConfig(config *Config, logger *logrus.Logger) {
 			// https://kgrz.io/reading-files-in-go-an-overview.html
 			config.LogFileHandle = file
 		} else {
-			log.Errorf("Failed to log to %s, will use %s instead.",
+			logger.Errorf("Failed to log to %s, will use %s instead.",
 				config.LogFilePath, config.ConsoleOutput)
 		}
 	}
@@ -87,15 +92,15 @@ func setLoggerConfig(config *Config, logger *logrus.Logger) {
 	// https://godoc.org/github.com/sirupsen/logrus#Logger
 
 	if config.UseSyslog {
-		log.Debug("Syslog logging requested, attempting to enable it")
+		logger.Debug("Syslog logging requested, attempting to enable it")
 		if err := enableSyslogLogging(config, logger); err != nil {
 			// TODO: Is this sufficient cause for failing? Perhaps if a local
 			// log file is not also set consider it a failure?
-			log.Errorf("Failed to enable syslog logging: %s", err)
-			log.Warn("Proceeding without syslog logging")
+			logger.Errorf("Failed to enable syslog logging: %s", err)
+			logger.Warn("Proceeding without syslog logging")
 		}
 	} else {
-		log.Debug("Syslog logging not requested, not enabling")
+		logger.Debug("Syslog logging not requested, not enabling")
 	}
 
 }

--- a/logging/logging_unix.go
+++ b/logging/logging_unix.go
@@ -16,11 +16,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package logging
 
 import (
 
 	"fmt"
+
+	"github.com/atc0005/elbow/config"
 
 	// Use `log` if we are going to override the default `log`, otherwise
 	// import without an "override" if we want to use the `logrus` name.
@@ -35,7 +37,7 @@ import (
 
 )
 
-func enableSyslogLogging(config *Config, logger *logrus.Logger) error {
+func enableSyslogLogging(config *config.Config, logger *logrus.Logger) error {
 
 	// make sure that the user actually requested syslog logging as it is
 	// currently supported on UNIX only.

--- a/logging/logging_windows.go
+++ b/logging/logging_windows.go
@@ -16,7 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package logging
 
 import (
 	// Use `log` if we are going to override the default `log`, otherwise
@@ -27,9 +27,11 @@ import (
 	// TODO: Is this needed here with a global `log` objection already created
 	// from this package?
 	"github.com/sirupsen/logrus"
+
+	"github.com/atc0005/elbow/config"
 )
 
-func enableSyslogLogging(config *Config, logger *logrus.Logger) error {
+func enableSyslogLogging(config *config.Config, logger *logrus.Logger) error {
 
 	// make sure that the user actually requested syslog logging as it is
 	// currently supported on UNIX only.
@@ -38,7 +40,7 @@ func enableSyslogLogging(config *Config, logger *logrus.Logger) error {
 		return fmt.Errorf("syslog logging not requested, not enabling")
 	}
 
-	log.Debug("This is a Windows build. Syslog support is not currently supported for this platform.")
+	logger.Debug("This is a Windows build. Syslog support is not currently supported for this platform.")
 
 	return nil
 

--- a/main_test.go
+++ b/main_test.go
@@ -16,7 +16,11 @@
 
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/atc0005/elbow/config"
+)
 
 func TestMain(t *testing.T) {
 
@@ -24,7 +28,7 @@ func TestMain(t *testing.T) {
 	appDescription := "prunes content matching specific patterns, either in a single directory or recursively through a directory tree."
 	appURL := "https://github.com/atc0005/elbow"
 
-	defaultConfig := NewConfig(appName, appDescription, appURL, version)
+	defaultConfig := config.NewConfig(appName, appDescription, appURL, version)
 
 	var emptySlice = []string{}
 	var nilSlice []string


### PR DESCRIPTION
This is inspired by #76, but also because I've known for a while that this might eventually be needed. I'm hoping to better isolate code from the main package in the hope/belief that this will make setting up future tests easier and more reliable.

As part of this work, the majority of the existing utility functions had to be renamed to export them for use elsewhere and a few functions had to be updated to accept a Config
object in order to receive application-wide settings. This Config object also (now) bundles a `*logrus.Logger` for shared use across the application.

I don't know Golang well enough at this point to know whether this is a terrible idea. If you're reading this and *you* know the answer, please reach out and share.

fixes #87
