### PR TITLE
Update godoc Help output example per v0.5.1

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -64,27 +64,27 @@ Help output is below. See the README for examples.
    ELBOW x.y.z
    https://github.com/atc0005/elbow
 
-   Usage: elbow [--pattern PATTERN] [--extensions EXTENSIONS] [--age AGE] [--keep KEEP] [--keep-old] [--remove] [--ignore-errors] [--log-level LOG-LEVEL] [--log-format LOG-FORMAT] [--log-file LOG-FILE] [--console-output CONSOLE-OUTPUT] [--use-syslog] [--paths PATHS] [--recurse]
+   Usage: elbow [--pattern PATTERN] [--extensions EXTENSIONS] [--age AGE] --keep KEEP [--keep-old] [--remove] [--ignore-errors] [--log-level LOG-LEVEL] [--log-format LOG-FORMAT] [--log-file LOG-FILE] [--console-output CONSOLE-OUTPUT] [--use-syslog] --paths PATHS [--recurse]
 
    Options:
    --pattern PATTERN      Substring pattern to compare filenames against. Wildcards are not supported.
    --extensions EXTENSIONS
-                           Limit search to specified file extensions. Specify as space separated list to match multiple required extensions.
-   --age AGE              Limit search to files that are the specified number of days old or older.
+                          Limit search to specified file extensions. Specify as space separated list to match multiple required extensions.
+   --age AGE              Limit search to files that are the specified number of days old or older. [default: 0]
    --keep KEEP            Keep specified number of matching files per provided path.
-   --keep-old             Keep oldest files instead of newer per provided path.
-   --remove               Remove matched files per provided path.
-   --ignore-errors        Ignore errors encountered during file removal.
+   --keep-old             Keep oldest files instead of newer per provided path. [default: false]
+   --remove               Remove matched files per provided path. [default: false]
+   --ignore-errors        Ignore errors encountered during file removal. [default: false]
    --log-level LOG-LEVEL
-                           Maximum log level at which messages will be logged. Log messages below this threshold will be discarded. [default: info]
+                          Maximum log level at which messages will be logged. Log messages below this threshold will be discarded. [default: info]
    --log-format LOG-FORMAT
                            Log formatter used by logging package. [default: text]
-   --log-file LOG-FILE    Optional log file used to hold logged messages. If set, log messages are not displayed on the console.
+   --log-file LOG-FILE     Optional log file used to hold logged messages. If set, log messages are not displayed on the console.
    --console-output CONSOLE-OUTPUT
-                           Specify how log messages are logged to the console. [default: stdout]
-   --use-syslog           Log messages to syslog in addition to other outputs. Not supported on Windows.
+                          Specify how log messages are logged to the console. [default: stdout]
+   --use-syslog           Log messages to syslog in addition to other outputs. Not supported on Windows. [default: false]
    --paths PATHS          List of comma or space-separated paths to process.
-   --recurse              Perform recursive search into subdirectories per provided path.
+   --recurse              Perform recursive search into subdirectories per provided path. [default: false]
    --help, -h             display this help and exit
    --version              display version and exit
 


### PR DESCRIPTION
As of #86 most of the default flag settings are exposed in the Help output. This commit updates the godoc example to reflect current Help output availabe in master and scheduled for the v0.5.1 release.