### PR TITLE
Fix nil pointer dereference: initialize logger

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -92,6 +92,9 @@ func NewConfig(appName, appDescription, appURL, appVersion string) *Config {
 	// Note: The majority of the default settings are supplied via struct tags
 	var config Config
 
+	// Initialize logger "handle" for later use
+	config.Logger = logrus.New()
+
 	config.AppName = appName
 	config.AppDescription = appDescription
 	config.AppURL = appURL


### PR DESCRIPTION
The `config.Logger` "handle" is now initialized as part of calling `config.NewConfig()` and is accessible
as intended when referenced elsewhere in the application.

fixes #94