### PR TITLE
Report total size of files

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -16,6 +16,39 @@ specific language governing permissions and limitations under the License.
 
 
 
+Stefan Nilsson
+https://yourbasic.org/golang/formatting-byte-size-to-human-readable-format/
+https://creativecommons.org/licenses/by/3.0/
+
+You are free to:
+
+Share - copy and redistribute the material in any medium or format
+Adapt - remix, transform, and build upon the material for any purpose, even
+commercially.
+
+This license is acceptable for Free Cultural Works. The licensor cannot revoke
+these freedoms as long as you follow the license terms.
+
+Under the following terms:
+
+Attribution - You must give appropriate credit, provide a link to the license,
+and indicate if changes were made. You may do so in any reasonable manner, but
+not in any way that suggests the licensor endorses you or your use.
+
+No additional restrictions - You may not apply legal terms or technological
+measures that legally restrict others from doing anything the license permits.
+
+Notices: You do not have to comply with the license for elements of the
+material in the public domain or where your use is permitted by an applicable
+exception or limitation. No warranties are given. The license may not give you
+all of the permissions necessary for your intended use. For example, other
+rights such as publicity, privacy, or moral rights may limit how you use the
+material.
+
+
+
+
+
 https://github.com/alexflint/go-arg/blob/master/LICENSE
 
 Copyright (c) 2015, Alex Flint

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package logging is intended mostly as a set of helper functions around
+// configuring and using a common logger to provide structured, leveled
+// logging.
 package logging
 
 import (

--- a/matches/matches.go
+++ b/matches/matches.go
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package matches provides types and functions intended to help with
+// collecting and validating file search results against required criteria.
 package matches
 
 import (
@@ -24,22 +26,47 @@ import (
 	"time"
 
 	"github.com/atc0005/elbow/config"
+	"github.com/atc0005/elbow/units"
 	"github.com/sirupsen/logrus"
 )
 
 // FileMatch represents a superset of statistics (including os.FileInfo) for a
 // file matched by provided search criteria. This allows us to record the
-// original full path while also
+// original full path while also recording file metadata used in later
+// calculations.
 type FileMatch struct {
 	os.FileInfo
 	Path string
 }
 
-// FileMatches is a slice of FileMatch objects
-// TODO: Do I really need to abstract the fact that FileMatches is a slice of
-// FileMatch objects? It seems that by hiding this it makes it harder to see
-// that we're working with a slice?
+// FileMatches is a slice of FileMatch objects that represents the search
+// results based on user-specified criteria.
 type FileMatches []FileMatch
+
+// TotalFileSize returns the cumulative size of all files in the slice in bytes
+func (fm FileMatches) TotalFileSize() int64 {
+
+	var totalSize int64
+
+	for _, file := range fm {
+
+		totalSize += file.Size()
+	}
+
+	return totalSize
+
+}
+
+// TotalFileSizeHR returns a human-readable string of the cumulative size of
+// all files in the slice of bytes
+func (fm FileMatches) TotalFileSizeHR() string {
+	return units.ByteCountIEC(fm.TotalFileSize())
+}
+
+// SizeHR returns a human-readable string of the size of a FileMatch object.
+func (fm FileMatch) SizeHR() string {
+	return units.ByteCountIEC(fm.Size())
+}
 
 // HasMatchingExtension validates whether a file has the desired extension
 func HasMatchingExtension(filename string, config *config.Config) bool {

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package paths provides various functions and types related to processing
+// paths in the filesystem, often for the purpose of removing older/unwanted
+// files.
 package paths
 
 import (
@@ -26,6 +29,35 @@ import (
 	"github.com/atc0005/elbow/matches"
 	"github.com/sirupsen/logrus"
 )
+
+// ProcessingResults is used to collect execution results for use in logging
+// and output summary presentation to the user
+type ProcessingResults struct {
+
+	// Number of files eligible for removal. This is before files are excluded
+	// by request per user request.
+	EligibleRemove int
+
+	// Number of files successfully removed.
+	SuccessRemoved int
+
+	// Number of files failed to remove.
+	FailedRemoved int
+
+	// Size of all files eligible for removal.
+	EligibleFileSize int64
+
+	// Size of all files successfully removed.
+	SuccessTotalFileSize int64
+
+	// Size of all files failed to remove.
+	FailedTotalFileSize int64
+
+	// Size of all files successfully and unsuccessfully removed. This is
+	// essentially the size of eligible files to be removed minus any files
+	// that are excluded by user request.
+	TotalProcessedFileSize int64
+}
 
 // PathPruningResults represents the number of files that were successfully
 // removed and those that were not. This is used in various calculations and

--- a/testing/setup_testenv.sh
+++ b/testing/setup_testenv.sh
@@ -36,6 +36,20 @@ fi
 
 while read line
 do
+    # Get random number between 1-10
+    #RAND_NUM="$(shuf -i 1-10 -n 1)"
+    # https://stackoverflow.com/questions/2556190/random-number-from-a-range-in-a-bash-script
+    RAND_NUM="$(python3 -S -c 'import random; print(random.randrange(1,10))')"
+
+
+    # Use that random number to create a non-zero byte sized file for testing
+    truncate -s ${RAND_NUM}M ${TEST_DIR_PATH1}/${line}
     touch -d $(echo $line | awk -F\- '{print $4}') ${TEST_DIR_PATH1}/${line}
+
+    # Get random number between 1-10
+    RAND_NUM="$(python -S -c 'import random; print random.randrange(1,10)')"
+
+    # Use that random number to create a non-zero byte sized file for testing
+    truncate -s ${RAND_NUM}K ${TEST_DIR_PATH2}/${line}
     touch -d $(echo $line | awk -F\- '{print $4}') ${TEST_DIR_PATH2}/${line}
 done < ${PATH_TO_THIS_SCRIPT}/sample_files_list_dev_web_app_server.txt

--- a/units/units.go
+++ b/units/units.go
@@ -1,0 +1,41 @@
+// Package units provides helper functions to perform conversions between
+// various units of measurement.
+package units
+
+import "fmt"
+
+// ByteCountSI converts a size in bytes to a human-readable string in SI
+// (decimal) format.
+// https://yourbasic.org/golang/formatting-byte-size-to-human-readable-format/
+// https://creativecommons.org/licenses/by/3.0/
+func ByteCountSI(b int64) string {
+	const unit = 1000
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB",
+		float64(b)/float64(div), "kMGTPE"[exp])
+}
+
+// ByteCountIEC converts a size in bytes to a human-readable string in IEC
+// (binary) format.
+// https://yourbasic.org/golang/formatting-byte-size-to-human-readable-format/
+// https://creativecommons.org/licenses/by/3.0/
+func ByteCountIEC(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB",
+		float64(b)/float64(div), "KMGTPE"[exp])
+}


### PR DESCRIPTION
- Add `units` package
  - provide conversion between common formats
  - `ByteCountIEC()` converts a size in bytes to a
     human-readable string in IEC (binary) format
  - `ByteCountSI()` converts a size in bytes to a
     human-readable string in SI (decimal) format
  - both functions are generously shared/provided
    by Stefan Nilsson through yourbasic.org

- Makefile `testenv` recipe updated to generate randomly
  sized test files (between 1-10 MB for path1 and 1-10 KB
  for path2)

- Add file size field to structured log output for file removal

- Use human readable file sizes for success/fail list

- Report file sizes as cumulative total (bytes) and as human
  readable strings

- Summary report at end of removal

References:

- https://yourbasic.org/golang/formatting-byte-size-to-human-readable-format/
- https://yourbasic.org/about/

---

fixes #70 