### PR TITLE
Update GitHub Actions workflow to use Makefile, latest Go and Ubuntu Linux LTS versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,13 +3,25 @@ on: [push]
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        # Supported versions of Go
+        go-version: [1.12.x, 1.13.x]
+
+        # Supported LTS versions of Ubuntu Linux
+        os: [ubuntu-16.04, ubuntu-18.04]
+
     steps:
       - name: Set up Go 1.13
         uses: actions/setup-go@v1
         with:
           go-version: 1.13
         id: go
+
+      - name: Install Linux packages
+        if: matrix.platform == 'ubuntu-latest'
+        run: sudo apt update && sudo apt install -y --no-install-recommends make gcc
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
@@ -33,5 +45,8 @@ jobs:
           go get -u honnef.co/go/tools/cmd/staticcheck
           staticcheck ./...
 
-      - name: Build
+      - name: Build with default options
         run: go build -v .
+
+      - name: Build using project Makefile
+        run: make all


### PR DESCRIPTION
- Use Ubuntu Linux LTS v16.04 and v18.04
- Use Go v1.12.x and v1.13.x
- Install dependencies in Ubuntu
- Label default build as such
- Use Makefile to run `all` recipe

fixes #104