### PR TITLE
Update GHA workflow to match correct matrix options

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,26 +1,79 @@
 name: Go
-on: [push, pull_request]
+
+# Run builds for Pull Requests (new, updated)
+on: [pull_request]
+  # push:
+  #   branches:
+  #     - master
+  # pull_request:
+
 jobs:
-  build:
-    name: Build
-    runs-on: ${{ matrix.platform }}
+
+  # Run linting job first to allow the workflow to fail without wasting time
+  # and CI resources
+  lint:
+    name: Lint codebase
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         # Supported versions of Go
         go-version: [1.12.x, 1.13.x]
 
-        # Supported LTS versions of Ubuntu Linux
-        os: [ubuntu-16.04, ubuntu-18.04]
+        # The latest Ubuntu version is sufficient for linting
+        os: [ubuntu-latest]
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+
+      - name: golangci-lint
+        run: |
+          export PATH=${PATH}:$(go env GOPATH)/bin
+          go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+          golangci-lint run
+
+      - name: Staticcheck
+        run: |
+          # add executables installed with go get to PATH
+          # TODO: this will hopefully be fixed by
+          # https://github.com/actions/setup-go/issues/14
+          export PATH=${PATH}:$(go env GOPATH)/bin
+          go get -u honnef.co/go/tools/cmd/staticcheck
+          staticcheck ./...
+
+
+  build:
+    # Don't build until all linting checks have passed
+    needs: lint
+    name: Build codebase
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Supported versions of Go
+        go-version: [1.12.x, 1.13.x]
+
+        # Supported LTS and latest version of Ubuntu Linux
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest]
 
     steps:
       - name: Set up Go 1.13
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: ${{ matrix.go-version }}
         id: go
 
-      - name: Install Linux packages
-        if: matrix.platform == 'ubuntu-latest'
+      - name: Install Ubuntu packages
+        if: contains(matrix.os, 'ubuntu')
         run: sudo apt update && sudo apt install -y --no-install-recommends make gcc
 
       - name: Check out code into the Go module directory


### PR DESCRIPTION
The $matrix.platform match was used previously when we only
tested against `ubuntu-latest`. The current logic is stubbed out in anticipation of testing against other distros in the near future.

refs #107