### PR TITLE
Update GHAW to only use ubuntu-latest for now

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,7 +63,10 @@ jobs:
         go-version: [1.12.x, 1.13.x]
 
         # Supported LTS and latest version of Ubuntu Linux
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest]
+        #os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest]
+
+        # This should be good enough until we learn otherwise
+        os: [ubuntu-latest]
 
     steps:
       - name: Set up Go


### PR DESCRIPTION
Instead of (likely) wasting CI time and resources, stick with just linting and building on the latest Ubuntu release for now.