### PR TITLE
Remove duplicate linting steps from GHAW

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -86,21 +86,6 @@ jobs:
         run: |
           go get -v -t -d ./...
 
-      - name: golangci-lint
-        run: |
-          export PATH=${PATH}:$(go env GOPATH)/bin
-          go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-          golangci-lint run
-
-      - name: Staticcheck
-        run: |
-          # add executables installed with go get to PATH
-          # TODO: this will hopefully be fixed by
-          # https://github.com/actions/setup-go/issues/14
-          export PATH=${PATH}:$(go env GOPATH)/bin
-          go get -u honnef.co/go/tools/cmd/staticcheck
-          staticcheck ./...
-
       - name: Build with default options
         run: go build -v .
 


### PR DESCRIPTION
Remove duplicate linting steps from the build job. That job was meant to exclude those linting steps since they would have already run as part of an earlier job.