### PR TITLE
Add additional linting to GitHub Actions workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,6 +31,16 @@ jobs:
           go-version: ${{ matrix.go-version }}
         id: go
 
+      - name: Install Go linting tools outside of Go module directory
+        run: |
+          # add executables installed with go get to PATH
+          # TODO: this will hopefully be fixed by
+          # https://github.com/actions/setup-go/issues/14
+          export PATH=${PATH}:$(go env GOPATH)/bin
+          go get -u golang.org/x/lint/golint
+          go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+          go get -u honnef.co/go/tools/cmd/staticcheck
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
 
@@ -42,11 +52,45 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
         run: sudo apt update && sudo apt install -y --no-install-recommends make gcc
 
+      - name: gofmt
+        run: |
+          # add executables installed with go get to PATH
+          # TODO: this will hopefully be fixed by
+          # https://github.com/actions/setup-go/issues/14
+          export PATH=${PATH}:$(go env GOPATH)/bin
+          # https://stackoverflow.com/a/42510278/903870
+          diff -u <(echo -n) <(-l -e -d .)
+
+      - name: go vet
+        run: |
+          # add executables installed with go get to PATH
+          # TODO: this will hopefully be fixed by
+          # https://github.com/actions/setup-go/issues/14
+          export PATH=${PATH}:$(go env GOPATH)/bin
+          go vet ./...
+
+      - name: golint
+        run: |
+          # add executables installed with go get to PATH
+          # TODO: this will hopefully be fixed by
+          # https://github.com/actions/setup-go/issues/14
+          export PATH=${PATH}:$(go env GOPATH)/bin
+          golint -set_exit_status ./...
+
       - name: golangci-lint
         run: |
+          # add executables installed with go get to PATH
+          # TODO: this will hopefully be fixed by
+          # https://github.com/actions/setup-go/issues/14
           export PATH=${PATH}:$(go env GOPATH)/bin
-          go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-          golangci-lint run
+          # https://github.com/golangci/golangci-lint#supported-linters
+          golangci-lint run \
+            -E goimports \
+            -E gosec \
+            -E stylecheck \
+            -E goconst \
+            -E depguard \
+            -E prealloc
 
       - name: Staticcheck
         run: |
@@ -54,7 +98,6 @@ jobs:
           # TODO: this will hopefully be fixed by
           # https://github.com/actions/setup-go/issues/14
           export PATH=${PATH}:$(go env GOPATH)/bin
-          go get -u honnef.co/go/tools/cmd/staticcheck
           staticcheck ./...
 
       - name: Build with default options


### PR DESCRIPTION
- `go vet`
- `golint`
- `gofmt`
- `golangci-lint`
  - six additional checks

Also, move go get commands into common block before this
modules-enabled project is cloned in an effort to prevent
the go.mod and go.sum files from being unintentionally
extended with non-applicable dependencies (which could
potentially throw off later check results).

fixes #118