### PR TITLE
Extend Makefile to call wrapper linting script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,14 @@ GOCLEANCMD				=	go clean
 GITCLEANCMD				= 	git clean -xfd
 TESTENVCMD				=   bash testing/setup_testenv.sh
 TESTRUNCMD				=   bash testing/run_with_test_settings.sh
+LINTINGCMD				=   bash testing/run_linting_checks.sh
 
 .DEFAULT_GOAL := help
 
 # Targets will not work properly if a file with the same name is ever created
 # in this directory. We explicitly declare our targets to be phony by
 # making them a prerequisite of the special target .PHONY
-.PHONY: help clean goclean gitclean pristine all windows linux testenv testrun
+.PHONY: help clean goclean gitclean pristine all windows linux testenv testrun linting
 
 # WARNING: Make expects you to use tabs to introduce recipe lines
 help:
@@ -61,6 +62,7 @@ help:
 	@echo "  linux          to generate a binary file for Linux distros"
 	@echo "  testenv        setup test environment in Windows Subsystem for Linux or other Linux system"
 	@echo "  testrun        use wrapper script to call binary with test settings"
+	@echo "  linting        use wrapper script to run common linting checks"
 
 testenv:
 	@echo "Setting up test environment in \"$(TESTENVDIR1)\" and \"$(TESTENVDIR2)\""
@@ -71,6 +73,11 @@ testrun:
 	@echo "Calling wrapper script: $(TESTRUNCMD)"
 	@$(TESTRUNCMD) "$(OUTPUTBASEFILENAME)" "$(TESTENVDIR1)" "$(TESTENVDIR2)"
 	@echo "Finished running wrapper script"
+
+linting:
+	@echo "Calling wraper script: $(LINTINGCMD)"
+	@$(LINTINGCMD)
+	@echo "Finished running linting checks"
 
 goclean:
 	@echo "Removing object files and cached files ..."

--- a/testing/run_linting_checks.sh
+++ b/testing/run_linting_checks.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Copyright 2019 Adam Chalkley
+#
+# https://github.com/atc0005/elbow
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Purpose: Run common linters locally to confirm code quality
+
+
+# Go ahead and append $GOPATH/bin to $PATH in an effort to locate
+# the go linters referenced in this script.
+export PATH=${PATH}:$(go env GOPATH)/bin
+
+
+###########################################################
+# Run linters
+###########################################################
+
+
+# https://stackoverflow.com/a/42510278/903870
+diff -u <(echo -n) <(gofmt -l -e -d .)
+
+
+go vet ./...
+
+
+if ! which golint > /dev/null; then
+cat <<\EOF
+Error: Unable to locate "golint"
+
+Change your current working directory (e.g., "cd $HOME") and install golint
+with the following command:
+
+go get -u golang.org/x/lint/golint
+EOF
+    exit 1
+else
+    golint -set_exit_status ./...
+fi
+
+if ! which golangci-lint > /dev/null; then
+cat <<\EOF
+Error: Unable to locate "golangci-lint"
+
+Change your current working directory (e.g., "cd $HOME") and install golangci-lint
+with the following command:
+
+go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+EOF
+    exit 1
+else
+    golangci-lint run \
+        -E goimports \
+        -E gosec \
+        -E stylecheck \
+        -E goconst \
+        -E depguard \
+        -E prealloc
+fi
+
+
+if ! which staticcheck > /dev/null; then
+cat <<\EOF
+Error: Unable to locate "staticcheck"
+
+Change your current working directory (e.g., "cd $HOME") and install staticcheck
+with the following command:
+
+go get -u honnef.co/go/tools/cmd/staticcheck
+EOF
+    exit 1
+else
+    staticcheck ./...
+fi


### PR DESCRIPTION
- Add small shell script to check for common linters
  and fail with "go do this" style error messages
  if the linting tools are not found

- Add Makefile recipe to call wraper script to run
  local linting tests which are (at the moment) the
  equivalent of the GitHub Actions workflow used for
  Pull Requests

fixes #102