### PR TITLE
Update GitHub Action Workflow name

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Lint and Build codebase
+name: Validate Pull Request
 
 # Run builds for Pull Requests (new, updated)
 # `synchronized` seems to equate to pushing new commits to a linked branch


### PR DESCRIPTION
Update overall workflow name to make it distinct from the
job(s) that run as part of the workflow. The intent is to
make it easier to select a "group" of status checks via
the repo branch protection rule(s) and to better communicate
what the overall goal of the workflow is.

fixes #127