### PR TITLE
Extend makefile to manage multi-arch binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,19 @@
 # limitations under the License.
 
 *.test
+
+# Potential/temporary non-release build binaries
 *.exe
 
-# When building on non-Windows platform
-elbow
+# Release assets
+*-linux-386
+*-linux-386.sha256
+*-linux-amd64
+*-linux-amd64.sha256
+*-windows-386.exe
+*-windows-386.exe.sha256
+*-windows-amd64.exe
+*-windows-amd64.exe.sha256
 
 # UPX backup files
 elbow.ex~


### PR DESCRIPTION
- Generate x86 and x64 binaries for Linux and Windows
- Generate checksum files for each binary
- Prune binaries and checksum files as part of `make clean`
- Update `.gitignore` to ignore release assets

fixes #131 