### PR TITLE
Update GHAW to use recipe for installing linters

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,18 +31,16 @@ jobs:
           go-version: ${{ matrix.go-version }}
         id: go
 
-      - name: Install Go linting tools outside of Go module directory
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Install Go linting tools
         run: |
           # add executables installed with go get to PATH
           # TODO: this will hopefully be fixed by
           # https://github.com/actions/setup-go/issues/14
           export PATH=${PATH}:$(go env GOPATH)/bin
-          go get -u golang.org/x/lint/golint
-          go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-          go get -u honnef.co/go/tools/cmd/staticcheck
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+          make lintinstall
 
       - name: Get dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,14 @@ CHECKSUMCMD				=	sha256sum -b
 TESTENVCMD				=   bash testing/setup_testenv.sh
 TESTRUNCMD				=   bash testing/run_with_test_settings.sh
 LINTINGCMD				=   bash testing/run_linting_checks.sh
+LINTINSTALLCMD			=   bash testing/install_linting_tools.sh
 
 .DEFAULT_GOAL := help
 
 # Targets will not work properly if a file with the same name is ever created
 # in this directory. We explicitly declare our targets to be phony by
 # making them a prerequisite of the special target .PHONY
-.PHONY: help clean goclean gitclean pristine all windows linux testenv testrun linting
+.PHONY: help clean goclean gitclean pristine all windows linux testenv testrun linting lintinstall
 
 # WARNING: Make expects you to use tabs to introduce recipe lines
 help:
@@ -64,6 +65,7 @@ help:
 	@echo "  linux          to generate a binary file for Linux distros"
 	@echo "  testenv        setup test environment in Windows Subsystem for Linux or other Linux system"
 	@echo "  testrun        use wrapper script to call binary with test settings"
+	@echo "  lintinstall    use wrapper script to install common linting tools"
 	@echo "  linting        use wrapper script to run common linting checks"
 
 testenv:
@@ -75,6 +77,11 @@ testrun:
 	@echo "Calling wrapper script: $(TESTRUNCMD)"
 	@$(TESTRUNCMD) "$(OUTPUTBASEFILENAME)" "$(TESTENVDIR1)" "$(TESTENVDIR2)"
 	@echo "Finished running wrapper script"
+
+lintinstall:
+	@echo "Calling wraper script: $(LINTINSTALLCMD)"
+	@$(LINTINSTALLCMD)
+	@echo "Finished running linting tools install script"
 
 linting:
 	@echo "Calling wraper script: $(LINTINGCMD)"

--- a/testing/install_linting_tools.sh
+++ b/testing/install_linting_tools.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2019 Adam Chalkley
+#
+# https://github.com/atc0005/elbow
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Purpose: Helper script for installing linting tools used by this project
+
+export PATH=${PATH}:$(go env GOPATH)/bin
+
+# Temporarily disable module-aware mode so that we can install linting tools
+# without modifying this project's go.mod and go.sum files
+export GO111MODULE="off"
+go get -u golang.org/x/lint/golint
+go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+go get -u honnef.co/go/tools/cmd/staticcheck
+
+
+# Reset GO111MODULE back to the default
+export GO111MODULE=""

--- a/testing/run_linting_checks.sh
+++ b/testing/run_linting_checks.sh
@@ -41,10 +41,10 @@ if ! which golint > /dev/null; then
 cat <<\EOF
 Error: Unable to locate "golint"
 
-Change your current working directory (e.g., "cd $HOME") and install golint
-with the following command:
+Install golint with the following command:
 
-go get -u golang.org/x/lint/golint
+make lintinstall
+
 EOF
     exit 1
 else
@@ -55,10 +55,10 @@ if ! which golangci-lint > /dev/null; then
 cat <<\EOF
 Error: Unable to locate "golangci-lint"
 
-Change your current working directory (e.g., "cd $HOME") and install golangci-lint
-with the following command:
+Install golangci-lint with the following command:
 
-go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+make lintinstall
+
 EOF
     exit 1
 else
@@ -76,10 +76,10 @@ if ! which staticcheck > /dev/null; then
 cat <<\EOF
 Error: Unable to locate "staticcheck"
 
-Change your current working directory (e.g., "cd $HOME") and install staticcheck
-with the following command:
+Install staticcheck with the following command:
 
-go get -u honnef.co/go/tools/cmd/staticcheck
+make lintinstall
+
 EOF
     exit 1
 else


### PR DESCRIPTION
- Add wrapper script for installing common linting tools
- Update Makefile to provide recipe for wrapper script
- Update linter wrapper script to recommend make recipe
  for installing linters when linters are not found
- Update GitHub Actions Workflow to use `make lintinstall`
  for linter installation in order to de-dupe the linter
  installation maintenance process

fixes #136