### PR TITLE
Extend GitHub Actions Workflow to include Markdown linting

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -1,4 +1,20 @@
-name: Validate Pull Request
+# Copyright 2019 Adam Chalkley
+#
+# https://github.com/atc0005/elbow
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Validate Codebase
 
 # Run builds for Pull Requests (new, updated)
 # `synchronized` seems to equate to pushing new commits to a linked branch
@@ -8,7 +24,7 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  lint_and_build:
+  lint_and_build_code:
     name: Lint and Build codebase
     runs-on: ${{ matrix.os }}
     # Default: 360 minutes
@@ -26,6 +42,7 @@ jobs:
 
     steps:
       - name: Set up Go
+        # https://github.com/actions/setup-go
         uses: actions/setup-go@v1
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -1,0 +1,52 @@
+# Copyright 2019 Adam Chalkley
+#
+# https://github.com/atc0005/elbow
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Validate Docs
+
+# Run Workflow for Pull Requests (new, updated)
+# `synchronized` seems to equate to pushing new commits to a linked branch
+# (whether force-pushed or not)
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  lint_markdown:
+    name: Lint Markdown files
+    runs-on: "ubuntu-latest"
+    # Default: 360 minutes
+    timeout-minutes: 10
+
+    steps:
+      - name: Setup Node
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "10.x"
+
+      - name: Install Markdown linting tools
+        run: |
+          npm install markdownlint --save-dev
+          npm install -g markdownlint-cli
+
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Run Markdown linting tools
+        run: |
+          # The `.markdownlint.yml` file specifies config settings for this
+          # linter, including which linting rules to ignore.
+          markdownlint '**/*.md' --ignore node_modules

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,31 @@
+# Copyright 2019 Adam Chalkley
+#
+# https://github.com/atc0005/elbow
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# https://github.com/igorshubovych/markdownlint-cli#configuration
+# https://github.com/DavidAnson/markdownlint#optionsconfig
+
+# Setting the special default rule to true or false includes/excludes all
+# rules by default.
+"default": true
+
+# We know that line lengths will be long in the main README file, so don't
+# report those cases.
+"MD013": false
+
+# Don't complain if sub-heading names are duplicated since this is a common
+# practice in CHANGELOG.md (e.g., "Fixed").
+"MD024":
+  "siblings_only": true

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Elbow, Elbow grease.
 
 [![Latest Release](https://img.shields.io/github/release/atc0005/elbow.svg?style=flat-square)](https://github.com/atc0005/elbow/releases/latest)
 [![GoDoc](https://godoc.org/github.com/atc0005/elbow?status.svg)](https://godoc.org/github.com/atc0005/elbow)
-![Validate Pull Request](https://github.com/atc0005/elbow/workflows/Validate%20Pull%20Request/badge.svg)
+![Validate Codebase](https://github.com/atc0005/elbow/workflows/Validate%20Codebase/badge.svg)
+![Validate Docs](https://github.com/atc0005/elbow/workflows/Validate%20Docs/badge.svg)
 
 - [elbow](#elbow)
   - [Project home](#project-home)


### PR DESCRIPTION
Overall:

- Install Node
- Install markdownlint-cli
- Run markdownlint-cli

Other:

- Rename existing workflow to better
  communicate WHAT it does and not WHEN
  it does it (since this new workflow also
  validates pull requests)

- Add markdownlint-cli config file with settings
  to disable rules that don't really apply
  to our usage
  - disable long line complaints since
    we have long lines in the main README
    to illustrate tool usage
  - disable sub-headings name duplication
    since our CHANGELOG follows the KeepAChangelog
    format and it duplicates sub-headings

---

- fixes #146 
- Inspired by the linting error found on #145