### PR TITLE
Add config file, pre-config initialization logging support

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -15,6 +15,32 @@ specific language governing permissions and limitations under the License.
 
 
 
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
+The MIT License (MIT)
+
+Copyright (c) 2013 - 2017 Thomas Pelletier, Eric Anderton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
 
 Stefan Nilsson
 https://yourbasic.org/golang/formatting-byte-size-to-human-readable-format/

--- a/config.example.toml
+++ b/config.example.toml
@@ -14,28 +14,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-*.test
+[filehandling]
 
-# Potential/temporary non-release build binaries
-elbow
-elbow.exe
+pattern = "reach-masterdev-"
 
-# Release assets
-*-linux-386
-*-linux-386.sha256
-*-linux-amd64
-*-linux-amd64.sha256
-*-windows-386.exe
-*-windows-386.exe.sha256
-*-windows-amd64.exe
-*-windows-amd64.exe.sha256
+file_extensions = [
+    ".war",
+    ".tmp",
+]
 
-# UPX related files
-elbow.ex~
-elbow.~
-.upx
-elbow.upx
+file_age = 1
+
+files_to_keep = 2
+
+keep_oldest = false
+
+remove = false
+
+ignore_errors = true
 
 
-# Ignore local copy of config file
-config.toml
+[search]
+
+# Multi-line array
+# https://github.com/toml-lang/toml#user-content-array
+paths = [
+    "/tmp/elbow/path1",
+    "/tmp/elbow/path2",
+]
+
+recursive_search = true
+
+
+[logging]
+
+log_level = "info"
+
+log_format = "text"
+
+# If set, all output to the console will be muted and sent here instead
+log_file_path = "/tmp/test.txt"
+
+console_output = "stdout"
+
+use_syslog = true

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ go 1.13
 
 require (
 	github.com/alexflint/go-arg v1.2.0
+	github.com/pelletier/go-toml v1.6.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/alexflint/go-arg v1.2.0 h1:TOFkN8/Cn1VvbHhsCuYq+P6ol3P5FAmjKIqsk7D2U/Q=
 github.com/alexflint/go-arg v1.2.0/go.mod h1:3Rj4baqzWaGGmZA2+bVTV8zQOZEjBQAPBnL5xLT+ftY=
 github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=
@@ -8,6 +10,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
+github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
@@ -23,3 +27,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -20,61 +20,128 @@
 package logging
 
 import (
+	"fmt"
 	"os"
 	"strings"
-
-	"github.com/atc0005/elbow/config"
 
 	"github.com/sirupsen/logrus"
 )
 
-// SetLoggerConfig applies the requested logger configuration settings
-func SetLoggerConfig(config *config.Config) {
+// LogRecord holds logrus.Field values along with additional metadata that can be
+// used later to complete the log message submission process.
+type LogRecord struct {
+	Level   logrus.Level
+	Message string
+	Fields  logrus.Fields
+}
 
-	logger := config.Logger
+// LogBuffer represents a slice of LogRecord objects
+type LogBuffer []LogRecord
 
-	switch config.LogFormat {
+// Add passed LogRecord type to slice of LogRecord objects
+func (lb *LogBuffer) Add(r LogRecord) {
+	*lb = append(*lb, r)
+}
+
+// Flush LogRecord entries after applying user-provided logging settings
+func (lb LogBuffer) Flush(logger *logrus.Logger) {
+
+	for _, entry := range lb {
+
+		switch {
+
+		case entry.Level == logrus.PanicLevel:
+			logger.WithFields(entry.Fields).Panic(entry.Message)
+
+		case entry.Level == logrus.FatalLevel:
+			logger.WithFields(entry.Fields).Fatal(entry.Message)
+
+		case entry.Level == logrus.ErrorLevel:
+			logger.WithFields(entry.Fields).Error(entry.Message)
+
+		case entry.Level == logrus.WarnLevel:
+			logger.WithFields(entry.Fields).Warn(entry.Message)
+
+		case entry.Level == logrus.InfoLevel:
+			logger.WithFields(entry.Fields).Info(entry.Message)
+
+		case entry.Level == logrus.DebugLevel:
+			logger.WithFields(entry.Fields).Debug(entry.Message)
+
+		case entry.Level == logrus.TraceLevel:
+			logger.WithFields(entry.Fields).Trace(entry.Message)
+
+		default:
+			panic("This should not have been reachable")
+
+		}
+
+	}
+
+	// TODO: Empty slice now that we're done processing all items
+
+}
+
+// SetLoggerFormatter sets a user-specified logging format for the provided
+// logger object.
+func SetLoggerFormatter(logger *logrus.Logger, format string) {
+	switch format {
 	case "text":
 		logger.SetFormatter(&logrus.TextFormatter{})
 	case "json":
 		// Log as JSON instead of the default ASCII formatter.
 		logger.SetFormatter(&logrus.JSONFormatter{})
 	}
+}
 
-	// NOTE: If config.LogFile is set, console output is muted
+// SetLoggerConsoleOutput configures the chosen console output to one of
+// stdout or stderr.
+func SetLoggerConsoleOutput(logger *logrus.Logger, consoleOutput string) {
 	var loggerOutput *os.File
 	switch {
-	case config.ConsoleOutput == "stdout":
+	case consoleOutput == "stdout":
 		loggerOutput = os.Stdout
-	case config.ConsoleOutput == "stderr":
+	case consoleOutput == "stderr":
 		loggerOutput = os.Stderr
-	}
-
-	if strings.TrimSpace(config.LogFilePath) != "" {
-		// If this is set, do not log to console unless writing to log file fails
-		// FIXME: How do we defer the file close without killing the file handle?
-		// https://github.com/sirupsen/logrus/blob/de736cf91b921d56253b4010270681d33fdf7cb5/logger.go#L332
-		file, err := os.OpenFile(config.LogFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-		if err == nil {
-			loggerOutput = file
-
-			// This is what we'll use to close the file handle from main()
-			// https://kgrz.io/reading-files-in-go-an-overview.html
-			config.LogFileHandle = file
-		} else {
-			logger.Errorf("Failed to log to %s, will use %s instead.",
-				config.LogFilePath, config.ConsoleOutput)
-		}
 	}
 
 	// Apply chosen output based on earlier checks
 	// Note: Can be any io.Writer
 	logger.SetOutput(loggerOutput)
+}
+
+// SetLoggerLogFile configures a log file as the destination for all log
+// messages. NOTE: If successfully set, console output is muted.
+func SetLoggerLogFile(logger *logrus.Logger, logFilePath string) (*os.File, error) {
+
+	var file *os.File
+	var err error
+
+	if strings.TrimSpace(logFilePath) != "" {
+		// If this is set, do not log to console unless writing to log file fails
+		// FIXME: How do we defer the file close without killing the file handle?
+		// https://github.com/sirupsen/logrus/blob/de736cf91b921d56253b4010270681d33fdf7cb5/logger.go#L332
+		file, err = os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			return nil, fmt.Errorf("failed to log to %s, will leave configuration as is",
+				logFilePath)
+		}
+		// The `file` handle is what we'll use to close the file handle from main()
+		// https://kgrz.io/reading-files-in-go-an-overview.html
+		logger.SetOutput(file)
+	}
+
+	return file, nil
+}
+
+// SetLoggerLevel applies the requested logger level to filter out messages
+// with a lower level than the one configured.
+func SetLoggerLevel(logger *logrus.Logger, logLevel string) {
 
 	// https://godoc.org/github.com/sirupsen/logrus#Level
 	// https://golang.org/pkg/log/syslog/#Priority
 	// https://en.wikipedia.org/wiki/Syslog#Severity_level
-	switch config.LogLevel {
+	switch logLevel {
 	case "emerg", "panic":
 		logger.SetLevel(logrus.PanicLevel)
 	case "alert", "critical", "fatal":
@@ -89,21 +156,6 @@ func SetLoggerConfig(config *config.Config) {
 		logger.SetLevel(logrus.DebugLevel)
 	case "trace":
 		logger.SetLevel(logrus.TraceLevel)
-	}
-
-	// https://godoc.org/github.com/sirupsen/logrus#New
-	// https://godoc.org/github.com/sirupsen/logrus#Logger
-
-	if config.UseSyslog {
-		logger.Debug("Syslog logging requested, attempting to enable it")
-		if err := enableSyslogLogging(config, logger); err != nil {
-			// TODO: Is this sufficient cause for failing? Perhaps if a local
-			// log file is not also set consider it a failure?
-			logger.Errorf("Failed to enable syslog logging: %s", err)
-			logger.Warn("Proceeding without syslog logging")
-		}
-	} else {
-		logger.Debug("Syslog logging not requested, not enabling")
 	}
 
 }

--- a/logging/logging_windows.go
+++ b/logging/logging_windows.go
@@ -19,28 +19,20 @@
 package logging
 
 import (
-	// Use `log` if we are going to override the default `log`, otherwise
-	// import without an "override" if we want to use the `logrus` name.
-	// https://godoc.org/github.com/sirupsen/logrus
-	"fmt"
-
-	// TODO: Is this needed here with a global `log` objection already created
-	// from this package?
 	"github.com/sirupsen/logrus"
-
-	"github.com/atc0005/elbow/config"
 )
 
-func enableSyslogLogging(config *config.Config, logger *logrus.Logger) error {
+// EnableSyslogLogging attempts to enable local syslog logging for non-Windows
+// systems. For Windows systems the attempt is skipped.
+func EnableSyslogLogging(logger *logrus.Logger, logBuffer *LogBuffer, logLevel string) error {
 
-	// make sure that the user actually requested syslog logging as it is
-	// currently supported on UNIX only.
-
-	if !config.UseSyslog {
-		return fmt.Errorf("syslog logging not requested, not enabling")
-	}
-
-	logger.Debug("This is a Windows build. Syslog support is not currently supported for this platform.")
+	logBuffer.Add(LogRecord{
+		// TODO: Not sure what log level is appropriate here. We are already
+		// reporting failures enabling syslog logging from the caller, but are
+		// not noting elsewhere that Windows syslog support is not available.
+		Level:   logrus.WarnLevel,
+		Message: "This is a Windows build. Syslog support is not currently supported for this platform.",
+	})
 
 	return nil
 

--- a/matches/matches.go
+++ b/matches/matches.go
@@ -201,16 +201,54 @@ func InList(needle string, haystack []string) bool {
 	return false
 }
 
-// SortByModTimeAsc sorts slice of FileMatches in ascending order
+// SortByModTimeAsc sorts slice of FileMatch objects in ascending order with
+// older values listed first.
 func (fm FileMatches) SortByModTimeAsc() {
 	sort.Slice(fm, func(i, j int) bool {
 		return fm[i].ModTime().Before(fm[j].ModTime())
 	})
 }
 
-// SortByModTimeDesc sorts slice of FileMatches in descending order
+// SortByModTimeDesc sorts slice of FileMatch objects in descending order with
+// newer values listed first.
 func (fm FileMatches) SortByModTimeDesc() {
 	sort.Slice(fm, func(i, j int) bool {
 		return fm[i].ModTime().After(fm[j].ModTime())
 	})
+}
+
+// FilesToPrune receives a slice of FileMatch objects and a config object.
+// Returns a slice of FileMatch objects selected based on the current config
+// object settings.
+func (fm FileMatches) FilesToPrune(c *config.Config) FileMatches {
+
+	log := c.Logger
+
+	var pruneStartRange int
+	var pruneEndRange int
+
+	switch {
+	case c.NumFilesToKeep > len(fm):
+		log.Debug("Specified number to keep is larger than total matches; will process all matches")
+		pruneStartRange = 0
+		pruneEndRange = len(fm)
+	case c.KeepOldest:
+		fm.SortByModTimeAsc()
+		log.Debug("Keeping older files by sorting in ascending order")
+		pruneStartRange = 0
+		pruneEndRange = (len(fm) - c.NumFilesToKeep)
+	case !c.KeepOldest:
+		fm.SortByModTimeDesc()
+		log.Debug("Keeping newer files by sorting in descending order")
+		pruneStartRange = 0
+		pruneEndRange = (len(fm) - c.NumFilesToKeep)
+	}
+
+	log.WithFields(logrus.Fields{
+		"start_range": pruneStartRange,
+		"end_range":   pruneEndRange,
+		"num_to_keep": c.NumFilesToKeep,
+	}).Debug("Building list of files to prune by skipping forward specified number of files to keep")
+
+	return fm[pruneStartRange:pruneEndRange]
 }

--- a/testing/generate_example_output.sh
+++ b/testing/generate_example_output.sh
@@ -7,6 +7,8 @@
 #
 # Run `make testenv` before running this script.
 
+# Generate basic binary for testing purposes
+go build
 
 # Text output example
 ./elbow \

--- a/testing/run_with_test_settings.sh
+++ b/testing/run_with_test_settings.sh
@@ -42,6 +42,8 @@ export ELBOW_USE_SYSLOG="false"
 export ELBOW_LOG_FORMAT="json"
 export ELBOW_REMOVE="false"
 #export ELBOW_LOG_FILE="testing-masterqa-build-removals.txt"
+#export ELBOW_CONFIG_FILE="config.example.toml"
+#export ELBOW_CONFIG_FILE="config.toml"
 
 echo -e "\n\nCalling ${BINARY_NAME} without flags; rely on env vars\n"
 ./${BINARY_NAME}
@@ -149,3 +151,48 @@ if [[ $? -ne 0 ]]; then
   echo "${BINARY_NAME} execution failed. See earlier output for details."
   sleep 3
 fi
+
+
+# Attempt to use config.toml config file from the root of the repo
+echo -e "\n\nCalling ${BINARY_NAME} with config file flag and paths command-line flag"
+
+echo "Unset all ELBOW_* environment variables to prevent shadowing tests with config file"
+unset ELBOW_PATHS
+unset ELBOW_FILE_PATTERN
+unset ELBOW_EXTENSIONS
+unset ELBOW_KEEP
+unset ELBOW_FILE_AGE
+unset ELBOW_RECURSE
+unset ELBOW_KEEP_OLD
+unset ELBOW_IGNORE_ERRORS
+unset ELBOW_LOG_LEVEL
+unset ELBOW_USE_SYSLOG
+unset ELBOW_LOG_FORMAT
+unset ELBOW_REMOVE
+unset ELBOW_LOG_FILE
+unset ELBOW_CONFIG_FILE
+
+make testenv
+
+if [[ ! -f "config.toml" ]]; then
+  echo "config.toml not found."
+  echo "Tip: Use config.example.toml as a template."
+  echo "e.g., `cp config.example.toml config.toml`"
+  exit 1
+fi
+
+./${BINARY_NAME} \
+  --paths "${PATH1}" \
+  --config-file "config.toml"
+
+if [[ $? -ne 0 ]]; then
+  echo "${BINARY_NAME} execution failed. See earlier output for details."
+  sleep 3
+fi
+
+# Attempt to ONLY use config.toml config file from the root of the repo
+echo -e "\n\nCalling ${BINARY_NAME} with config file flag ONLY"
+
+make testenv
+
+./${BINARY_NAME} --config-file "config.toml"


### PR DESCRIPTION
## Overview

Add support for using a configuration file to supply application settings.
This is complimentary to existing environment variable and command-line
support. Some implementation details for the existing configuration sources
had to be modified in order to provide the new support. See the changes listed
for this Pull Request for additional information.

## Added

- Add TOML config file support
  - by way of `pelletier/go-toml` package
  - Add `config.example.toml` template/starter file

- LICENCE
  - Add license info from go-toml project to NOTICE file

- README
  - Update with precedence details
  - Update with new config file options table that maps those
    settings back to the equivalent command-line flags
  - Update log output examples to reflect no only config file
    command-line flags and related output, but also recent
    work to better summarize file size details (e.g., space
    reclaimed from pruning matching files)

- Create `MergeConfig()` function to handle merging
  default, config file and command-line argument
  settings
  - favors incoming config object, provided the source field being
    examined does not contain a default value
  - needs work
  - good candidate for replacement by the `imdario/mergo` package
    used by Docker, Kubernetes, VMware and other big name projects

- Use logging.LogBuffer to collect log messages for later
  replay once user-specified logging settings are in-place

- Extend doc comments for FileMatches sort methods

- Move FilesToPrune logic to FileMatches `FilesToPrune` method in
  matches package

## Changed

- Update `Config.Validate()` to assume full responsibility for
  enforcing 'required' settings in place of struct tags

- Change log level for Windows syslog attempt

- Update .gitignore to ignore config.toml file
  in case user wishes to keep config file alongside
  this code (for whatever reason)

- Update .gitignore to remove files no longer present
  or used

- Move `default` struct tag values back to
  constructor to improve compatibility between
  `pelletier/go-toml`, `alexflint/go-arg` (and potentially)
    other packages

- Update many doc comments in an effort to expand coverage, improve
  clarity (lots more to do here)

- Move logging config method to config package, break
  bulk of the code into separate functions within the logging
  package that are now orchestrated from the
  `Config.SetLoggerConfig()` method

## Fixed

- BUGFIX for `Config.String()` method (field repeat?)
- BUGFIX: Fix logic problems with FileMatches slice indexing
- BUGFIX: Various linting fixes

## References

- fixes #1
- fixes #154
