### PR TITLE
Update linting wrapper script: report error codes

### DIFF
--- a/testing/run_linting_checks.sh
+++ b/testing/run_linting_checks.sh
@@ -24,6 +24,9 @@
 # the go linters referenced in this script.
 export PATH=${PATH}:$(go env GOPATH)/bin
 
+# Assume all is well starting out
+final_exit_code=0
+failed_app=""
 
 ###########################################################
 # Run linters
@@ -33,9 +36,21 @@ export PATH=${PATH}:$(go env GOPATH)/bin
 # https://stackoverflow.com/a/42510278/903870
 diff -u <(echo -n) <(gofmt -l -e -d .)
 
+status=$?
+if [[ $status -ne 0 ]]; then
+    final_exit_code=$status
+    failed_app="gofmt"
+    echo "Non-zero exit code from $failed_app: $status"
+fi
 
 go vet ./...
 
+status=$?
+if [[ $status -ne 0 ]]; then
+    final_exit_code=$status
+    failed_app="go vet"
+    echo "Non-zero exit code from $failed_app: $status"
+fi
 
 if ! which golint > /dev/null; then
 cat <<\EOF
@@ -49,6 +64,14 @@ EOF
     exit 1
 else
     golint -set_exit_status ./...
+fi
+
+# TODO: This might not be needed based on use of "-set_exit_status"
+status=$?
+if [[ $status -ne 0 ]]; then
+    final_exit_code=$status
+    failed_app="staticcheck"
+    echo "Non-zero exit code from $failed_app: $status"
 fi
 
 if ! which golangci-lint > /dev/null; then
@@ -71,6 +94,12 @@ else
         -E prealloc
 fi
 
+status=$?
+if [[ $status -ne 0 ]]; then
+    final_exit_code=$status
+    failed_app="golangci-lint"
+    echo "Non-zero exit code from $failed_app: $status"
+fi
 
 if ! which staticcheck > /dev/null; then
 cat <<\EOF
@@ -85,3 +114,17 @@ EOF
 else
     staticcheck ./...
 fi
+
+status=$?
+if [[ $status -ne 0 ]]; then
+    final_exit_code=$status
+    failed_app="staticcheck"
+    echo "Non-zero exit code from $failed_app: $status"
+fi
+
+# Give feedback on linting failure cause
+if [[ $final_exit_code -ne 0 ]]; then
+    echo "Linting failed, most recent failure: $failed_app"
+fi
+
+exit $final_exit_code


### PR DESCRIPTION
While probably not near as idiomatic as it could be, this commit updates the wrapper script to explicitly check error codes and return any failures at the end of the run.

This should probably be revisited to clean it up further at some point.

fixes #177