### PR TITLE
Expand list of golangci-lint linters

### DIFF
--- a/testing/run_linting_checks.sh
+++ b/testing/run_linting_checks.sh
@@ -91,7 +91,13 @@ else
         -E stylecheck \
         -E goconst \
         -E depguard \
-        -E prealloc
+        -E prealloc \
+        -E misspell \
+        -E maligned \
+        -E dupl \
+        -E unconvert \
+        -E golint \
+        -E gocritic
 fi
 
 status=$?


### PR DESCRIPTION
Include some additional linters in an effort to better catch various code quality issues that I might be missing.

- `prealloc`
- `misspell`
- `maligned`
- `dupl`
- `unconvert`
- `golint`
- `gocritic`

fixes #180

refs https://github.com/golangci/golangci-lint#supported-linters