### PR TITLE
Fix sloppyLen linting error re slice length

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func main() {
 		log.Debugf("Length of matches slice: %d", len(fileMatches))
 
 		log.Debugf("Early exit if no matching files were found.")
-		if len(fileMatches) <= 0 {
+		if len(fileMatches) == 0 {
 
 			log.WithFields(logrus.Fields{
 				"path":         path,


### PR DESCRIPTION
I was mistakenly guarding against a potential negative slice length, which isn't needed. Fixed to check for empty slice instead.

fixes #182