### PR TITLE
Increase use of constants for common string comparison cases

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -410,16 +410,16 @@ func (c *Config) String() string {
 	// If the AppMetadata fields are empty, note that to aid in
 	// troubleshooting elsewhere in the codebase
 	if c.AppName == "" {
-		c.AppName = fieldValueNotSet
+		c.AppName = FieldValueNotSet
 	}
 	if c.AppDescription == "" {
-		c.AppDescription = fieldValueNotSet
+		c.AppDescription = FieldValueNotSet
 	}
 	if c.AppVersion == "" {
-		c.AppVersion = fieldValueNotSet
+		c.AppVersion = FieldValueNotSet
 	}
 	if c.AppURL == "" {
-		c.AppURL = fieldValueNotSet
+		c.AppURL = FieldValueNotSet
 	}
 
 	return fmt.Sprintf("AppName=%q, AppDescription=%q, AppVersion=%q, AppURL=%q, FilePattern=%q, FileExtensions=%q, Paths=%v, RecursiveSearch=%t, FileAge=%d, NumFilesToKeep=%d, KeepOldest=%t, Remove=%t, IgnoreErrors=%t, LogFormat=%q, LogFilePath=%q, ConfigFile=%q, ConsoleOutput=%q, LogLevel=%q, UseSyslog=%t, logger=%v, flagParser=%v,  logFileHandle=%v",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -50,9 +50,9 @@ func TestNewConfigFlagsOnly(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	// TODO: A useful way to automate retrieving the app name?
-	appName := strings.ToLower(defaultAppName)
-	if runtime.GOOS == windowsOSName {
-		appName += windowsAppSuffix
+	appName := strings.ToLower(DefaultAppName)
+	if runtime.GOOS == WindowsOSName {
+		appName += WindowsAppSuffix
 	}
 
 	// Note to self: Don't add/escape double-quotes here. The shell strips

--- a/config/constants.go
+++ b/config/constants.go
@@ -25,10 +25,28 @@ package config
 
 // Workarounds for golantci-lint errors:
 // string `STRING` has N occurrences, make it a constant (goconst)
-const fakeValue = "fakeValue"
-const defaultAppName string = "Elbow"
-const fieldValueNotSet string = "NotSet"
-const windowsOSName string = "windows"
-const logFormatText string = "text"
-const logFormatJSON string = "json"
-const windowsAppSuffix string = ".exe"
+const (
+	FakeValue        string = "fakeValue"
+	FieldValueNotSet string = "NotSet"
+	WindowsOSName    string = "windows"
+	WindowsAppSuffix string = ".exe"
+)
+
+const (
+
+	// DefaultAppName is the default name for this application
+	DefaultAppName string = "Elbow"
+
+	// DefaultAppDescription is the description for this application shown in
+	// HelpText output.
+	DefaultAppDescription string = "prunes content matching specific patterns, either in a single directory or recursively through a directory tree."
+
+	// DefaultAppVersion is a placeholder that is used when the application is
+	// compiled without the use of the Makefile (which handles setting the
+	// value via a build tag)
+	DefaultAppVersion string = "dev"
+
+	// DefaultAppURL is the website where users can learn more about the
+	// application, submit problem reports, etc.
+	DefaultAppURL string = "https://github.com/atc0005/elbow"
+)

--- a/config/get.go
+++ b/config/get.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/alexflint/go-arg"
+	"github.com/atc0005/elbow/logging"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,7 +28,7 @@ import (
 // otherwise
 func (c *Config) GetAppName() string {
 	if c == nil || c.AppName == "" {
-		return defaultAppName
+		return DefaultAppName
 	}
 	return c.AppName
 }
@@ -36,7 +37,7 @@ func (c *Config) GetAppName() string {
 // default value otherwise
 func (c *Config) GetAppDescription() string {
 	if c == nil || c.AppDescription == "" {
-		return "prunes content matching specific patterns, either in a single directory or recursively through a directory tree."
+		return DefaultAppDescription
 	}
 	return c.AppDescription
 
@@ -46,7 +47,7 @@ func (c *Config) GetAppDescription() string {
 // value otherwise
 func (c *Config) GetAppVersion() string {
 	if c == nil || c.AppVersion == "" {
-		return "dev"
+		return DefaultAppVersion
 	}
 	return c.AppVersion
 }
@@ -55,7 +56,7 @@ func (c *Config) GetAppVersion() string {
 // otherwise
 func (c *Config) GetAppURL() string {
 	if c == nil || c.AppURL == "" {
-		return "https://github.com/atc0005/elbow"
+		return DefaultAppURL
 	}
 	return c.AppURL
 }
@@ -152,7 +153,7 @@ func (c *Config) GetRecursiveSearch() bool {
 // otherwise
 func (c *Config) GetLogLevel() string {
 	if c == nil || c.LogLevel == nil {
-		return "info"
+		return logging.LogLevelInfo
 	}
 	return *c.LogLevel
 }
@@ -161,7 +162,7 @@ func (c *Config) GetLogLevel() string {
 // otherwise
 func (c *Config) GetLogFormat() string {
 	if c == nil || c.LogFormat == nil {
-		return logFormatText
+		return logging.LogFormatText
 	}
 	return *c.LogFormat
 }
@@ -179,7 +180,7 @@ func (c *Config) GetLogFilePath() string {
 // value otherwise.
 func (c *Config) GetConsoleOutput() string {
 	if c == nil || c.ConsoleOutput == nil {
-		return "stdout"
+		return logging.ConsoleOutputStdout
 	}
 	return *c.ConsoleOutput
 }

--- a/config/merge_complete_configs_test.go
+++ b/config/merge_complete_configs_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/alexflint/go-arg"
+	"github.com/atc0005/elbow/logging"
 	"github.com/sirupsen/logrus"
 )
 
@@ -204,10 +205,10 @@ func TestMergeConfigUsingCompleteConfigObjects(t *testing.T) {
 		{"ELBOW_REMOVE", "false"},
 		{"ELBOW_IGNORE_ERRORS", "false"},
 		{"ELBOW_RECURSE", "false"},
-		{"ELBOW_LOG_LEVEL", "warn"},
-		{"ELBOW_LOG_FORMAT", "text"},
+		{"ELBOW_LOG_LEVEL", logging.LogLevelWarn},
+		{"ELBOW_LOG_FORMAT", logging.LogFormatText},
 		{"ELBOW_LOG_FILE", "/var/log/elbow/env.log"},
-		{"ELBOW_CONSOLE_OUTPUT", "stdout"},
+		{"ELBOW_CONSOLE_OUTPUT", logging.ConsoleOutputStdout},
 		{"ELBOW_USE_SYSLOG", "false"},
 		{"ELBOW_CONFIG_FILE", "/tmp/config.toml"},
 		{"ELBOW_PATHS", "/tmp/elbow/path3"},
@@ -297,9 +298,9 @@ func TestMergeConfigUsingCompleteConfigObjects(t *testing.T) {
 	}
 
 	// TODO: A useful way to automate retrieving the app name?
-	appName := strings.ToLower(defaultAppName)
-	if runtime.GOOS == windowsOSName {
-		appName += windowsAppSuffix
+	appName := strings.ToLower(DefaultAppName)
+	if runtime.GOOS == WindowsOSName {
+		appName += WindowsAppSuffix
 	}
 
 	// Note to self: Don't add/escape double-quotes here. The shell strips
@@ -315,10 +316,10 @@ func TestMergeConfigUsingCompleteConfigObjects(t *testing.T) {
 		"--ignore-errors",
 		"--recurse",
 		"--keep-old",
-		"--log-level", "info",
+		"--log-level", logging.LogLevelInfo,
 		"--use-syslog",
-		"--log-format", "json",
-		"--console-output", "stderr",
+		"--log-format", logging.LogFormatJSON,
+		"--console-output", logging.ConsoleOutputStderr,
 		"--log-file", "/var/log/elbow/flags.log",
 		"--config-file", "/tmp/configfile.toml",
 		"--extensions", ".java", ".class",

--- a/config/merge_incomplete_configs_test.go
+++ b/config/merge_incomplete_configs_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/alexflint/go-arg"
+	"github.com/atc0005/elbow/logging"
 )
 
 // TODO: Evaluate replacing bare strings with constants (see constants.go)
@@ -46,8 +47,8 @@ func TestMergeConfigUsingIncompleteConfigObjects(t *testing.T) {
 	baseConfig.Paths = testBaseConfigPaths
 	baseConfig.logger = baseConfig.GetLogger()
 
-	// TODO: Any reason to set this? The Validate() method does not currently
-	// enforce that the FileExtensions field be set.
+	// Question: Any reason to set this? The Validate() method does not
+	// currently enforce that the FileExtensions field be set.
 	// Answer: Yes, because we want to ensure that the final MergeConfig()
 	// result reflects our test case(s).
 	//
@@ -131,8 +132,8 @@ func TestMergeConfigUsingIncompleteConfigObjects(t *testing.T) {
 	expectedFileAgeAfterFileMerge := 90
 	expectedNumFilesToKeepAfterFileMerge := 1
 	expectedRecursiveSearchAfterFileMerge := true
-	expectedLogLevelAfterFileMerge := "notice"
-	expectedLogFormatAfterFileMerge := logFormatText
+	expectedLogLevelAfterFileMerge := logging.LogLevelNotice
+	expectedLogFormatAfterFileMerge := logging.LogFormatText
 	expectedUseSyslogAfterFileMerge := true
 
 	expectedKeepOldestAfterFileMerge := baseConfig.GetKeepOldest()
@@ -219,7 +220,7 @@ func TestMergeConfigUsingIncompleteConfigObjects(t *testing.T) {
 		{"ELBOW_KEEP", "4"},
 		{"ELBOW_KEEP_OLD", "false"},
 		{"ELBOW_REMOVE", "true"},
-		{"ELBOW_LOG_FORMAT", "text"},
+		{"ELBOW_LOG_FORMAT", logging.LogFormatText},
 		{"ELBOW_LOG_FILE", "/var/log/elbow/env.log"},
 		{"ELBOW_PATHS", "/tmp/elbow/path3"},
 		{"ELBOW_EXTENSIONS", ".docx,.pptx"},
@@ -279,7 +280,7 @@ func TestMergeConfigUsingIncompleteConfigObjects(t *testing.T) {
 	expectedNumFilesToKeepAfterEnvVarsMerge := 4
 	expectedKeepOldestAfterEnvVarsMerge := false
 	expectedRemoveAfterEnvVarsMerge := true
-	expectedLogFormatAfterEnvVarsMerge := logFormatText
+	expectedLogFormatAfterEnvVarsMerge := logging.LogFormatText
 	expectedLogFilePathAfterEnvVarsMerge := "/var/log/elbow/env.log"
 
 	expectedRecursiveSearchAfterEnvVarsMerge := baseConfig.GetRecursiveSearch()
@@ -362,9 +363,9 @@ func TestMergeConfigUsingIncompleteConfigObjects(t *testing.T) {
 	flagsConfig.AppDescription = baseConfig.GetAppDescription()
 
 	// TODO: A useful way to automate retrieving the app name?
-	appName := strings.ToLower(defaultAppName)
-	if runtime.GOOS == windowsOSName {
-		appName += windowsAppSuffix
+	appName := strings.ToLower(DefaultAppName)
+	if runtime.GOOS == WindowsOSName {
+		appName += WindowsAppSuffix
 	}
 
 	// Note to self: Don't add/escape double-quotes here. The shell strips
@@ -376,9 +377,9 @@ func TestMergeConfigUsingIncompleteConfigObjects(t *testing.T) {
 		"--age", "5",
 		"--keep", "6",
 		"--remove",
-		"--log-level", "panic",
-		"--log-format", "json",
-		"--console-output", "stderr",
+		"--log-level", logging.LogLevelPanic,
+		"--log-format", logging.LogFormatJSON,
+		"--console-output", logging.ConsoleOutputStderr,
 		"--extensions", ".java", ".class",
 	}
 
@@ -415,9 +416,9 @@ func TestMergeConfigUsingIncompleteConfigObjects(t *testing.T) {
 	expectedFileAgeAfterFlagsMerge := 5
 	expectedNumFilesToKeepAfterFlagsMerge := 6
 	expectedRemoveAfterFlagsMerge := true
-	expectedLogFormatAfterFlagsMerge := logFormatJSON
-	expectedLogLevelAfterFlagsMerge := "panic"
-	expectedConsoleOutputAfterFlagsMerge := "stderr"
+	expectedLogFormatAfterFlagsMerge := logging.LogFormatJSON
+	expectedLogLevelAfterFlagsMerge := logging.LogLevelPanic
+	expectedConsoleOutputAfterFlagsMerge := logging.ConsoleOutputStderr
 
 	expectedBaseConfigAfterFlagsMerge := Config{
 		AppMetadata: AppMetadata{

--- a/config/validate.go
+++ b/config/validate.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"fmt"
+
+	"github.com/atc0005/elbow/logging"
 )
 
 // Validate verifies all struct fields have been provided acceptable values
@@ -99,8 +101,8 @@ func (c Config) Validate() error {
 	switch {
 	case c.LogFormat == nil:
 		return fmt.Errorf("field LogFormat not configured")
-	case *c.LogFormat == logFormatText:
-	case *c.LogFormat == logFormatJSON:
+	case *c.LogFormat == logging.LogFormatText:
+	case *c.LogFormat == logging.LogFormatJSON:
 	default:
 		return fmt.Errorf("invalid option %q provided for log format", *c.LogFormat)
 	}
@@ -115,8 +117,8 @@ func (c Config) Validate() error {
 	case c.ConsoleOutput == nil:
 		return fmt.Errorf("field ConsoleOutput not configured")
 	// TODO: Evaluate replacing bare strings with constants (see constants.go)
-	case *c.ConsoleOutput == "stdout":
-	case *c.ConsoleOutput == "stderr":
+	case *c.ConsoleOutput == logging.ConsoleOutputStdout:
+	case *c.ConsoleOutput == logging.ConsoleOutputStderr:
 	default:
 		return fmt.Errorf("invalid option %q provided for console output destination", *c.ConsoleOutput)
 	}
@@ -124,18 +126,17 @@ func (c Config) Validate() error {
 	switch {
 	case c.LogLevel == nil:
 		return fmt.Errorf("field LogLevel not configured")
-	// TODO: Evaluate replacing bare strings with constants (see constants.go)
-	case *c.LogLevel == "emergency":
-	case *c.LogLevel == "alert":
-	case *c.LogLevel == "critical":
-	case *c.LogLevel == "panic":
-	case *c.LogLevel == "fatal":
-	case *c.LogLevel == "error":
-	case *c.LogLevel == "warn":
-	case *c.LogLevel == "info":
-	case *c.LogLevel == "notice":
-	case *c.LogLevel == "debug":
-	case *c.LogLevel == "trace":
+	case *c.LogLevel == logging.LogLevelEmergency:
+	case *c.LogLevel == logging.LogLevelAlert:
+	case *c.LogLevel == logging.LogLevelCritical:
+	case *c.LogLevel == logging.LogLevelPanic:
+	case *c.LogLevel == logging.LogLevelFatal:
+	case *c.LogLevel == logging.LogLevelError:
+	case *c.LogLevel == logging.LogLevelWarn:
+	case *c.LogLevel == logging.LogLevelInfo:
+	case *c.LogLevel == logging.LogLevelNotice:
+	case *c.LogLevel == logging.LogLevelDebug:
+	case *c.LogLevel == logging.LogLevelTrace:
 	default:
 		return fmt.Errorf("invalid option %q provided for log level", *c.LogLevel)
 	}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"testing"
+
+	"github.com/atc0005/elbow/logging"
 )
 
 // TODO: Evaluate replacing bare strings with constants (see constants.go)
@@ -359,7 +361,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("LogFormat set to invalid value", func(t *testing.T) {
 		tmpLogFormat := *c.LogFormat
-		*c.LogFormat = fakeValue
+		*c.LogFormat = FakeValue
 		if err := c.Validate(); err == nil {
 			t.Errorf("Config passed, but should have failed on invalid value %q for LogFormat: %v", *c.LogFormat, err)
 		} else {
@@ -378,7 +380,7 @@ func TestValidate(t *testing.T) {
 	t.Run("LogFormat set to valid values", func(t *testing.T) {
 
 		tmpLogFormat := *c.LogFormat
-		tests := []string{"text", "json"}
+		tests := []string{logging.LogFormatText, logging.LogFormatJSON}
 		for _, v := range tests {
 			*c.LogFormat = v
 			if err := c.Validate(); err == nil {
@@ -437,7 +439,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("ConsoleOutput set to invalid value", func(t *testing.T) {
 		tmpConsoleOutput := *c.ConsoleOutput
-		*c.ConsoleOutput = fakeValue
+		*c.ConsoleOutput = FakeValue
 		if err := c.Validate(); err == nil {
 			t.Errorf("Config passed, but should have failed on invalid value %q for ConsoleOutput: %v", *c.ConsoleOutput, err)
 		} else {
@@ -456,7 +458,7 @@ func TestValidate(t *testing.T) {
 	t.Run("ConsoleOutput set to valid values", func(t *testing.T) {
 
 		tmpConsoleOutput := *c.ConsoleOutput
-		tests := []string{"stdout", "stderr"}
+		tests := []string{logging.ConsoleOutputStdout, logging.ConsoleOutputStderr}
 		for _, v := range tests {
 			*c.ConsoleOutput = v
 			if err := c.Validate(); err == nil {
@@ -497,7 +499,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("LogLevel set to invalid value", func(t *testing.T) {
 		tmpLogLevel := *c.LogLevel
-		*c.LogLevel = fakeValue
+		*c.LogLevel = FakeValue
 		if err := c.Validate(); err == nil {
 			t.Errorf("Config passed, but should have failed on invalid value %q for LogLevel: %v", *c.LogLevel, err)
 		} else {
@@ -517,17 +519,17 @@ func TestValidate(t *testing.T) {
 
 		tmpLogLevel := *c.LogLevel
 		tests := []string{
-			"emergency",
-			"alert",
-			"critical",
-			"panic",
-			"fatal",
-			"error",
-			"warn",
-			"info",
-			"notice",
-			"debug",
-			"trace",
+			logging.LogLevelEmergency,
+			logging.LogLevelAlert,
+			logging.LogLevelCritical,
+			logging.LogLevelPanic,
+			logging.LogLevelFatal,
+			logging.LogLevelError,
+			logging.LogLevelWarn,
+			logging.LogLevelInfo,
+			logging.LogLevelNotice,
+			logging.LogLevelDebug,
+			logging.LogLevelTrace,
 		}
 		for _, v := range tests {
 			*c.LogLevel = v

--- a/logging/constants.go
+++ b/logging/constants.go
@@ -1,0 +1,100 @@
+// Copyright 2019 Adam Chalkley
+//
+// https://github.com/atc0005/elbow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+// Fix linting error
+// string `fakeValue` has 3 occurrences, make it a constant (goconst)
+const fakeValue = "fakeValue"
+
+// Log levels
+const (
+	// https://godoc.org/github.com/sirupsen/logrus#Level
+	// https://golang.org/pkg/log/syslog/#Priority
+	// https://en.wikipedia.org/wiki/Syslog#Severity_level
+
+	// LogLevelEmergency represents messages at Emergency level. System is
+	// unusable; a panic condition. This level is mapped to logrus.PanicLevel
+	// and syslog.LOG_EMERG. logrus calls panic.
+	LogLevelEmergency string = "emergency"
+
+	// LogLevelPanic represents messages at Emergency level. System is
+	// unusable; a panic condition. This level is mapped to logrus.PanicLevel
+	// and syslog.LOG_EMERG. logrus calls panic.
+	LogLevelPanic string = "panic"
+
+	// LogLevelAlert represents a condition that should be corrected
+	// immediately, such as a corrupted system database. This level is mapped
+	// to logrus.FatalLevel and syslog.LOG_ALERT. logrus calls os.Exit(1)
+	LogLevelAlert string = "alert"
+
+	// LogLevelFatal is used for errors that should definitely be noted.
+	// Commonly used for hooks to send errors to an error tracking service.
+	// This level is mapped to logrus.FatalLevel and syslog.LOG_ALERT. logrus
+	// calls os.Exit(1)
+	LogLevelFatal string = "fatal"
+
+	// LogLevelCritical is for critical conditions, such as hard device
+	// errors. This level is mapepd to logrus.FatalLevel and syslog.LOG_CRIT.
+	// logrus calls os.Exit(1)
+	LogLevelCritical string = "critical"
+
+	// LogLevelError is for errors that should definitely be noted. Commonly
+	// used for hooks to send errors to an error tracking service. This level
+	// maps to logrus.ErrorLevel and syslog.LOG_ERR.
+	LogLevelError string = "error"
+
+	// LogLevelWarn is for non-critical entries that deserve eyes. This level
+	// maps to logrus.WarnLevel and syslog.LOG_WARNING.
+	LogLevelWarn string = "warn"
+
+	// LogLevelNotice is for normal but significant conditions; conditions
+	// that are not error conditions, but that may require special handling.
+	// This level maps to logrus.WarnLevel and syslog.LOG_NOTICE.
+	LogLevelNotice string = "notice"
+
+	// LogLevelInfo is for general application operational entries. This level
+	// maps to logrus.InfoLevel and syslog.LOG_INFO.
+	LogLevelInfo string = "info"
+
+	// LogLevelDebug is for debug-level messages and is usually on enabled
+	// when debugging. Very verbose logging. This level is mapped to
+	// logrus.DebugLevel and syslog.LOG_DEBUG.
+	LogLevelDebug string = "debug"
+
+	// LogLevelTrace is for finer-grained informational events than debug.
+	// This level maps to logrus.TraceLevel and syslog.LOG_DEBUG.
+	LogLevelTrace string = "trace"
+)
+
+// Log formats used by logrus
+const (
+
+	// LogFormatText represents the logrus text formatter.
+	LogFormatText string = "text"
+
+	// LogFormatJSON represents the logrus JSON formatter.
+	LogFormatJSON string = "json"
+)
+
+const (
+
+	// ConsoleOutputStdout represents os.Stdout
+	ConsoleOutputStdout string = "stdout"
+
+	// ConsoleOutputStderr represents os.Stderr
+	ConsoleOutputStderr string = "stderr"
+)

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -106,10 +106,9 @@ func (lb LogBuffer) Flush(logger *logrus.Logger) error {
 // logger object.
 func SetLoggerFormatter(logger *logrus.Logger, format string) error {
 	switch format {
-	// TODO: Evaluate replacing bare strings with constants (see constants.go)
-	case "text":
+	case LogFormatText:
 		logger.SetFormatter(&logrus.TextFormatter{})
-	case "json":
+	case LogFormatJSON:
 		// Log as JSON instead of the default ASCII formatter.
 		logger.SetFormatter(&logrus.JSONFormatter{})
 	default:
@@ -123,12 +122,10 @@ func SetLoggerFormatter(logger *logrus.Logger, format string) error {
 // stdout or stderr.
 func SetLoggerConsoleOutput(logger *logrus.Logger, consoleOutput string) error {
 
-	switch {
-	// TODO: Evaluate replacing bare strings with constants (see constants.go)
-	// TODO: Update switch statement to switch on consoleOutput
-	case consoleOutput == "stdout":
+	switch consoleOutput {
+	case ConsoleOutputStdout:
 		logger.SetOutput(os.Stdout)
-	case consoleOutput == "stderr":
+	case ConsoleOutputStderr:
 		logger.SetOutput(os.Stderr)
 	default:
 		return fmt.Errorf("invalid option provided: %v", consoleOutput)
@@ -166,25 +163,23 @@ func SetLoggerLogFile(logger *logrus.Logger, logFilePath string) (*os.File, erro
 // with a lower level than the one configured.
 func SetLoggerLevel(logger *logrus.Logger, logLevel string) error {
 
-	// TODO: Evaluate replacing bare strings with constants (see constants.go)
-
 	// https://godoc.org/github.com/sirupsen/logrus#Level
 	// https://golang.org/pkg/log/syslog/#Priority
 	// https://en.wikipedia.org/wiki/Syslog#Severity_level
 	switch logLevel {
-	case "emerg", "panic":
+	case LogLevelEmergency, LogLevelPanic:
 		logger.SetLevel(logrus.PanicLevel)
-	case "alert", "critical", "fatal":
+	case LogLevelAlert, LogLevelCritical, LogLevelFatal:
 		logger.SetLevel(logrus.FatalLevel)
-	case "error":
+	case LogLevelError:
 		logger.SetLevel(logrus.ErrorLevel)
-	case "warn", "notice":
+	case LogLevelWarn, LogLevelNotice:
 		logger.SetLevel(logrus.WarnLevel)
-	case "info":
+	case LogLevelInfo:
 		logger.SetLevel(logrus.InfoLevel)
-	case "debug":
+	case LogLevelDebug:
 		logger.SetLevel(logrus.DebugLevel)
-	case "trace":
+	case LogLevelTrace:
 		logger.SetLevel(logrus.TraceLevel)
 	default:
 		return fmt.Errorf("invalid option provided: %v", logLevel)

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -24,10 +24,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Fix linting error
-// string `fakeValue` has 3 occurrences, make it a constant (goconst)
-const fakeValue = "fakeValue"
-
 func TestLogBufferFlushNilLoggerShouldFail(t *testing.T) {
 
 	var nilLogger *logrus.Logger
@@ -125,17 +121,17 @@ func TestSetLoggerLevelShouldSucceed(t *testing.T) {
 
 	// TODO: Evaluate replacing bare strings with constants (see constants.go)
 	tests := []test{
-		test{logLevel: "emerg", loggerLevel: logrus.PanicLevel},
-		test{logLevel: "panic", loggerLevel: logrus.PanicLevel},
-		test{logLevel: "alert", loggerLevel: logrus.FatalLevel},
-		test{logLevel: "critical", loggerLevel: logrus.FatalLevel},
-		test{logLevel: "fatal", loggerLevel: logrus.FatalLevel},
-		test{logLevel: "error", loggerLevel: logrus.ErrorLevel},
-		test{logLevel: "warn", loggerLevel: logrus.WarnLevel},
-		test{logLevel: "notice", loggerLevel: logrus.WarnLevel},
-		test{logLevel: "info", loggerLevel: logrus.InfoLevel},
-		test{logLevel: "debug", loggerLevel: logrus.DebugLevel},
-		test{logLevel: "trace", loggerLevel: logrus.TraceLevel},
+		test{logLevel: LogLevelEmergency, loggerLevel: logrus.PanicLevel},
+		test{logLevel: LogLevelPanic, loggerLevel: logrus.PanicLevel},
+		test{logLevel: LogLevelAlert, loggerLevel: logrus.FatalLevel},
+		test{logLevel: LogLevelCritical, loggerLevel: logrus.FatalLevel},
+		test{logLevel: LogLevelFatal, loggerLevel: logrus.FatalLevel},
+		test{logLevel: LogLevelError, loggerLevel: logrus.ErrorLevel},
+		test{logLevel: LogLevelWarn, loggerLevel: logrus.WarnLevel},
+		test{logLevel: LogLevelNotice, loggerLevel: logrus.WarnLevel},
+		test{logLevel: LogLevelInfo, loggerLevel: logrus.InfoLevel},
+		test{logLevel: LogLevelDebug, loggerLevel: logrus.DebugLevel},
+		test{logLevel: LogLevelTrace, loggerLevel: logrus.TraceLevel},
 	}
 
 	logger := logrus.New()
@@ -182,10 +178,9 @@ func TestSetLoggerFormatterShouldSucceed(t *testing.T) {
 
 	logger := logrus.New()
 
-	// TODO: Evaluate replacing bare strings with constants (see constants.go)
 	tests := []test{
-		test{format: "text", result: nil},
-		test{format: "json", result: nil},
+		test{format: LogFormatText, result: nil},
+		test{format: LogFormatJSON, result: nil},
 	}
 
 	for _, give := range tests {
@@ -221,8 +216,8 @@ func TestSetLoggerConsoleOutputShouldSucceed(t *testing.T) {
 
 	// TODO: Evaluate replacing bare strings with constants (see constants.go)
 	tests := []test{
-		test{consoleOutput: "stdout", result: nil},
-		test{consoleOutput: "stderr", result: nil},
+		test{consoleOutput: ConsoleOutputStdout, result: nil},
+		test{consoleOutput: ConsoleOutputStderr, result: nil},
 	}
 
 	for _, give := range tests {

--- a/logging/logging_unix.go
+++ b/logging/logging_unix.go
@@ -44,44 +44,23 @@ func EnableSyslogLogging(logger *logrus.Logger, logBuffer *LogBuffer, logLevel s
 	var syslogLogLevel syslog.Priority
 
 	switch logLevel {
-	// TODO: Evaluate replacing bare strings with constants (see constants.go)
-	case "emerg", "panic":
-		// syslog: System is unusable; a panic condition.
-		// logrus: calls panic
+	case LogLevelEmergency, LogLevelPanic:
 		syslogLogLevel = syslog.LOG_EMERG
-	case "alert", "fatal":
-		// syslog: A condition that should be corrected immediately, such as a
-		// corrupted system database
-		// logrus: calls os.Exit(1)
+	case LogLevelAlert, LogLevelFatal:
 		syslogLogLevel = syslog.LOG_ALERT
-	case "critical":
-		// syslog: Critical conditions, such as hard device errors.
+	case LogLevelCritical:
 		syslogLogLevel = syslog.LOG_CRIT
-	case "error":
-		// syslog: Error conditions
-		// logrus: Used for errors that should definitely be noted. Commonly
-		// used for hooks to send errors to an error tracking service.
+	case LogLevelError:
 		syslogLogLevel = syslog.LOG_ERR
-	case "warn":
-		// syslog: Warning conditions
-		// logrus: Non-critical entries that deserve eyes.
+	case LogLevelWarn:
 		syslogLogLevel = syslog.LOG_WARNING
-	case "notice":
-		// syslog: Normal but significant conditions; conditions that are not
-		// error conditions, but that may require special handling.
-		// logrus: N/A
+	case LogLevelNotice:
 		syslogLogLevel = syslog.LOG_NOTICE
-	case "info":
-		// syslog: Informational messages
-		// logrus: General application operational entries
+	case LogLevelInfo:
 		syslogLogLevel = syslog.LOG_INFO
-	case "debug":
-		// syslog: Debug-level messages
-		// logrus: Usually only enabled when debugging. Very verbose logging.
+	case LogLevelDebug:
 		syslogLogLevel = syslog.LOG_DEBUG
-	case "trace":
-		// syslog: N/A
-		// logrus: Finer-grained informational events than debug.
+	case LogLevelTrace:
 		syslogLogLevel = syslog.LOG_DEBUG
 	default:
 		return fmt.Errorf("invalid syslog log level: %q", logLevel)

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ var version = "x.y.z"
 // TODO: Move this elsewhere to a dedicated location.
 // TODO: Create a metadata subpackage?
 // TODO: Evaluate replacing bare strings with constants (see constants.go)
-var defaultAppName = "Elbow"
+const defaultAppName = "Elbow"
 
 func main() {
 

--- a/main_test.go
+++ b/main_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/atc0005/elbow/config"
+	"github.com/atc0005/elbow/logging"
 )
 
 func TestMain(t *testing.T) {
@@ -35,9 +36,9 @@ func TestMain(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	// TODO: A useful way to automate retrieving the app name?
-	appName := "elbow"
-	if runtime.GOOS == "windows" {
-		appName += ".exe"
+	appName := config.DefaultAppName
+	if runtime.GOOS == config.WindowsOSName {
+		appName += config.WindowsAppSuffix
 	}
 
 	// Note to self: Don't add/escape double-quotes here. The shell strips
@@ -49,10 +50,10 @@ func TestMain(t *testing.T) {
 		"--keep", "1",
 		"--recurse",
 		"--keep-old",
-		"--log-level", "info",
+		"--log-level", logging.LogLevelInfo,
 		"--use-syslog",
-		"--log-format", "text",
-		"--console-output", "stdout",
+		"--log-format", logging.LogFormatText,
+		"--console-output", logging.ConsoleOutputStdout,
 	}
 
 	// TODO: Flesh this out


### PR DESCRIPTION
Replace common string values for `Set*`, `Validate` and other methods and functions which are likely to result in (more) subtle bugs in the future. I found at least one case where the `emergency` option for the command-line flag `--log-level` was likely not used as intended.

fixes #186