### PR TITLE
Remove AppMetadata field guards in Config.String()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -407,21 +407,6 @@ func (c Config) Version() string {
 // formatting if using the TextFormatter logrus formatter.
 func (c *Config) String() string {
 
-	// If the AppMetadata fields are empty, note that to aid in
-	// troubleshooting elsewhere in the codebase
-	if c.AppName == "" {
-		c.AppName = FieldValueNotSet
-	}
-	if c.AppDescription == "" {
-		c.AppDescription = FieldValueNotSet
-	}
-	if c.AppVersion == "" {
-		c.AppVersion = FieldValueNotSet
-	}
-	if c.AppURL == "" {
-		c.AppURL = FieldValueNotSet
-	}
-
 	return fmt.Sprintf("AppName=%q, AppDescription=%q, AppVersion=%q, AppURL=%q, FilePattern=%q, FileExtensions=%q, Paths=%v, RecursiveSearch=%t, FileAge=%d, NumFilesToKeep=%d, KeepOldest=%t, Remove=%t, IgnoreErrors=%t, LogFormat=%q, LogFilePath=%q, ConfigFile=%q, ConsoleOutput=%q, LogLevel=%q, UseSyslog=%t, logger=%v, flagParser=%v,  logFileHandle=%v",
 
 		c.GetAppName(),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -213,6 +213,12 @@ func TestLoadConfigFileTemplate(t *testing.T) {
 			t.Log("Loaded configuration file")
 		}
 
+		t.Log("LoadConfigFile wiped the existing struct, reconstructing AppMetadata fields to pass validation checks")
+		c.AppName = c.GetAppName()
+		c.AppVersion = c.GetAppVersion()
+		c.AppURL = c.GetAppURL()
+		c.AppDescription = c.GetAppDescription()
+
 		t.Logf("Current config settings: %s", c.String())
 
 		if err := c.Validate(); err != nil {


### PR DESCRIPTION
In short, the guard checks do not appear to be needed.

Whether this is due to recent work to remove the support for overriding the `AppMetadata` fields via external config sources I do not recall.

By removing this code we rely entirely on the Getter methods defined for the purpose handling `AppMetadata` field values.

fixes #195