### PR TITLE
Ignore directories from non-recursive eval

### DIFF
--- a/paths/paths.go
+++ b/paths/paths.go
@@ -251,6 +251,11 @@ func ProcessPath(config *config.Config, path string) (matches.FileMatches, error
 		// FileMatch objects
 		for _, file := range files {
 
+			// ignore directories
+			if file.IsDir() {
+				continue
+			}
+
 			filename := file.Name()
 
 			// Apply validity checks against filename. If validity fails,


### PR DESCRIPTION
The recursive code path is already tossing directories from the results list, but we were not doing the same for the non-recursive evaluation. This commit applies the same logic to both code paths.

fixes #198