### PR TITLE
Fix value saved in FileMatch.Path field

### DIFF
--- a/paths/paths.go
+++ b/paths/paths.go
@@ -294,7 +294,11 @@ func ProcessPath(config *config.Config, path string) (matches.FileMatches, error
 
 			// If we made it to this point, then we must assume that the file
 			// has met all criteria to be removed by this application.
-			fileMatch := matches.FileMatch{FileInfo: file, Path: filename}
+			fileMatch := matches.FileMatch{
+				FileInfo: file,
+				Path:     filepath.Join(path, file.Name()),
+			}
+
 			fileMatches = append(fileMatches, fileMatch)
 		}
 	}


### PR DESCRIPTION
Unintentionally, we were saving only the actual filename, not the fully-qualified path to a file. We fix this by explicitly joining the path we evaluate with each file found within that location and then saving this new value within `FileMatch.Path`.

fixes #201