### PR TITLE
Update Go versions used in CI: drop 1.12, add 1.14

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         # Supported versions of Go
-        go-version: [1.12.x, 1.13.x]
+        go-version: [1.13.x, 1.14.x]
 
         # Supported LTS and latest version of Ubuntu Linux
         #os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest]


### PR DESCRIPTION
Drop:

- 1.12

Use the latest versions of:

- 1.13
- 1.14

fixes #220