### PR TITLE
Install golangci-lint binary instead of from src

### DIFF
--- a/testing/install_linting_tools.sh
+++ b/testing/install_linting_tools.sh
@@ -21,12 +21,18 @@
 
 export PATH=${PATH}:$(go env GOPATH)/bin
 
+# https://github.com/golangci/golangci-lint#install
+# https://github.com/golangci/golangci-lint/releases/latest
+GOLANGCI_LINT_VERSION="v1.25.0"
+
 # Temporarily disable module-aware mode so that we can install linting tools
 # without modifying this project's go.mod and go.sum files
 export GO111MODULE="off"
 go get -u golang.org/x/lint/golint
-go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 go get -u honnef.co/go/tools/cmd/staticcheck
+
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+golangci-lint --version
 
 
 # Reset GO111MODULE back to the default


### PR DESCRIPTION
Use official installation instructions

- fixes #175 
- refs #228 