### PR TITLE
golangci-lint: Add scopelint linter

### DIFF
--- a/testing/run_linting_checks.sh
+++ b/testing/run_linting_checks.sh
@@ -97,7 +97,8 @@ else
         -E dupl \
         -E unconvert \
         -E golint \
-        -E gocritic
+        -E gocritic \
+        -E scopelint
 fi
 
 status=$?


### PR DESCRIPTION
Include this linter in the list when running linting checks.

- fixes #231
- refs atc0005/todo#1