### PR TITLE
Use nolint:dogsled to ignore specific sites

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,8 @@ import (
 func GetBaseProjectDir(t *testing.T) string {
 
 	// https://stackoverflow.com/questions/23847003/golang-tests-and-working-directory
-	_, filename, _, _ := runtime.Caller(1)
+	// TODO: How else to retrieve only the one value that I need? See GH-237.
+	_, filename, _, _ := runtime.Caller(1) // nolint:dogsled
 	// The ".." reflects the path above the current working directory
 	dir := path.Join(path.Dir(filename), "..")
 	return dir

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -194,6 +194,7 @@ func SetLoggerLevel(logger *logrus.Logger, logLevel string) error {
 // line number from the point this function was called.
 // TODO: Find a better location for this utility function
 func GetLineNumber() int {
-	_, _, line, _ := runtime.Caller(1)
+	// TODO: How else to retrieve only the one value that I need? See GH-237.
+	_, _, line, _ := runtime.Caller(1) // nolint:dogsled
 	return line
 }


### PR DESCRIPTION
I'm not sure how else to go about retrieving just the one value that I need from the four that are returned, so I am using `// nolint:dogsled` to hotfix the specific warnings returned. I'm doing this because I'd like to keep the linter active for other cases that I *can* fix with my current level of knowledge, but do not want these specific problem cases to cause CI linting
failures.

fixes #237