### PR TITLE
Add golangci-lint linter & update, README updates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - maligned
     - dupl
     - unconvert
+    - gofmt
     - golint
     - gocritic
     - scopelint

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ VERSION 				= $(shell git describe --always --long --dirty)
 
 # https://github.com/golangci/golangci-lint#install
 # https://github.com/golangci/golangci-lint/releases/latest
-GOLANGCI_LINT_VERSION		= v1.25.0
+GOLANGCI_LINT_VERSION		= v1.25.1
 
 # The default `go build` process embeds debugging information. Building
 # without that debugging information reduces the binary size by around 28%.
@@ -98,7 +98,6 @@ lintinstall:
 	@export PATH="${PATH}:$(go env GOPATH)/bin"
 
 	@echo "Explicitly enabling Go modules mode per command"
-	(cd; GO111MODULE="on" go get golang.org/x/lint/golint)
 	(cd; GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck)
 
 	@echo Installing golangci-lint ${GOLANGCI_LINT_VERSION} per official binary installation docs ...
@@ -113,17 +112,8 @@ lintinstall:
 linting:
 	@echo "Running linting tools ..."
 
-	@echo "Running gofmt ..."
-
-	@test -z $(shell gofmt -l -e .) || (echo "WARNING: gofmt linting errors found" \
-		&& gofmt -l -e -d . \
-		&& exit 1 )
-
 	@echo "Running go vet ..."
 	@go vet -mod=vendor $(shell go list -mod=vendor ./... | grep -v /vendor/)
-
-	@echo "Running golint ..."
-	@golint -set_exit_status $(shell go list -mod=vendor ./... | grep -v /vendor/)
 
 	@echo "Running golangci-lint ..."
 	@golangci-lint run

--- a/README.md
+++ b/README.md
@@ -118,17 +118,19 @@ Tested using:
    - for CentOS Linux
      1. `sudo yum install make gcc`
 1. Build
-   - for current operating system with default `go` build options
-     - `go build ./cmd/elbow/`
-       - Go 1.14+ automatically uses bundled dependencies in top-level
-         `vendor` folder
-       - Go 1.11, 1.12 and 1.13 will default to fetching dependencies
+   - for current operating system
      - `go build -mod=vendor ./cmd/elbow/`
-       - force build to use bundled dependencies in top-level `vendor` folder
+       - *forces build to use bundled dependencies in top-level `vendor`
+         folder*
    - for all supported platforms (where `make` is installed)
+      - `make all`
+   - for Windows
+      - `make windows`
+   - for Linux
+     - `make linux`
 1. Copy the applicable binary to whatever systems needs to run it
-   1. Linux: `/tmp/elbow/elbow`
-   1. Windows: `/tmp/elbow/elbow.exe`
+   - if using `Makefile`: look in `/tmp/release_assets/elbow/`
+   - if using `go build`: look in `/tmp/elbow/`
 
 ## Setup test environment
 


### PR DESCRIPTION
## Changes

- Update golangci-lint to v1.25.1

- Remove gofmt and golint as separate checks, enable these linters in golangci-lint config

- Update README to list accurate build/deploy steps based on recent restructuring work

## References

- fixes #244
- fixes #245
- fixes #247

- refs atc0005/todo#6
- refs atc0005/todo#10