### PR TITLE
Restore missing version output since v0.7.0

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -184,8 +184,15 @@ func NewConfig(appVersion string) (*Config, error) {
 	// This object will always be set in some manner as either flags or env
 	// vars will be needed to bootstrap the application. While we may support
 	// using a configuration file to provide settings, it is not used by
-	// default.
-	argsConfig := Config{}
+	// default. Directly add app version string here since this is the config
+	// object referenced if the user requests either `--version` or `-h`
+	// flags; the combined config object is not created in time to serve either
+	// of those needs.
+	argsConfig := Config{
+		AppMetadata: AppMetadata{
+			AppVersion: appVersion,
+		},
+	}
 
 	// Initialize logger "handle" for later use
 	baseConfig.logger = logrus.New()


### PR DESCRIPTION
The version string shown in both the Help and Version flag output has been missing since v0.7.0 when support for setting configuration information via config files was added and config merging precedence was reworked.

We provide the missing information by directly initializing the appropriate metadata field for the flags config struct prior to calling `arg.MustParse()`. This ensures that the version info is available when the `Version()` method is called by the `alexflint/go-arg` package.

fixes GH-240