### PR TITLE
golangci-lint | Disable default exclusions in cfg

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+issues:
+  # equivalent CLI flag: --exclude-use-default
+  #
+  # see:
+  #   atc0005/todo#29
+  #   golangci-lint/golangci-lint#1249
+  #   golangci-lint/golangci-lint#413
+  exclude-use-default: false
+
 linters:
   enable:
     - dogsled


### PR DESCRIPTION
Add explicit config settings to disable default exclusions.

This same config change will need to be pushed to all other repos where I am using this config set.

- fixes atc0005/elbow#273
- refs atc0005/todo#29