### PR TITLE
Fix linting errors found by GH-274

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path"
 	"runtime"
@@ -206,7 +207,18 @@ func TestLoadConfigFileTemplate(t *testing.T) {
 		} else {
 			t.Log("Successfully opened config file", exampleConfigFile)
 		}
-		defer fh.Close()
+		defer func() {
+			if err := fh.Close(); err != nil {
+				// Ignore "file already closed" errors
+				if !errors.Is(err, os.ErrClosed) {
+					t.Errorf(
+						"failed to close file %q: %s",
+						exampleConfigFile,
+						err.Error(),
+					)
+				}
+			}
+		}()
 
 		if err := c.LoadConfigFile(fh); err != nil {
 			t.Error("Unable to load configuration file:", err)

--- a/config/merge_complete_configs_test.go
+++ b/config/merge_complete_configs_test.go
@@ -217,7 +217,9 @@ func TestMergeConfigUsingCompleteConfigObjects(t *testing.T) {
 
 	for _, table := range envVarTables {
 		t.Logf("Setting %q to %q", table.envVar, table.value)
-		os.Setenv(table.envVar, table.value)
+		if err := os.Setenv(table.envVar, table.value); err != nil {
+			t.Errorf("Unable to set environment variable: %v", err)
+		}
 	}
 
 	// https://stackoverflow.com/questions/33723300/how-to-test-the-passing-of-arguments-in-golang
@@ -262,7 +264,10 @@ func TestMergeConfigUsingCompleteConfigObjects(t *testing.T) {
 	// Unset environment variables that we just set
 	for _, table := range envVarTables {
 		t.Logf("Unsetting %q\n", table.envVar)
-		os.Unsetenv(table.envVar)
+		if err := os.Unsetenv(table.envVar); err != nil {
+			t.Errorf("Unable to unset environment variable: %v", err)
+
+		}
 	}
 
 	//

--- a/config/merge_incomplete_configs_test.go
+++ b/config/merge_incomplete_configs_test.go
@@ -236,7 +236,9 @@ func TestMergeConfigUsingIncompleteConfigObjects(t *testing.T) {
 
 	for _, table := range envVarTables {
 		t.Logf("Setting %q to %q", table.envVar, table.value)
-		os.Setenv(table.envVar, table.value)
+		if err := os.Setenv(table.envVar, table.value); err != nil {
+			t.Errorf("Unable to set environment variable: %v", err)
+		}
 	}
 
 	// https://stackoverflow.com/questions/33723300/how-to-test-the-passing-of-arguments-in-golang
@@ -347,7 +349,10 @@ func TestMergeConfigUsingIncompleteConfigObjects(t *testing.T) {
 	// Unset environment variables that we just set
 	for _, table := range envVarTables {
 		t.Logf("Unsetting %q\n", table.envVar)
-		os.Unsetenv(table.envVar)
+		if err := os.Unsetenv(table.envVar); err != nil {
+			t.Errorf("Unable to unset environment variable: %v", err)
+
+		}
 	}
 
 	//

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -22,6 +22,7 @@ package logging
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -146,7 +147,11 @@ func SetLoggerLogFile(logger *logrus.Logger, logFilePath string) (*os.File, erro
 		// If this is set, do not log to console unless writing to log file fails
 		// FIXME: How do we defer the file close without killing the file handle?
 		// https://github.com/sirupsen/logrus/blob/de736cf91b921d56253b4010270681d33fdf7cb5/logger.go#L332
-		file, err = os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		file, err = os.OpenFile(
+			filepath.Clean(logFilePath),
+			os.O_CREATE|os.O_WRONLY|os.O_APPEND,
+			0600,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to log to %s, will leave configuration as is",
 				logFilePath)


### PR DESCRIPTION
Fix a variety of linting issues flagged by golangci-lint using settings introduced in GH-274.

- `errcheck`
- `gosec`
    - log file permissions
    - file inclusion via variable
- `stylecheck`

---

fixes GH-277