### PR TITLE
CI | Remove local golangci-lint config

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -36,7 +36,14 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2.3.1
 
-      - name: Run golangci-lint using repo-provided config file settings
+      - name: Remove repo-provided golangci-lint config file
+        run: |
+          # Remove the copy of the config file bundled with the repo/code so
+          # that the configuration provided by the atc0005/go-ci project is
+          # used instead
+          rm -vf .golangci.yml
+
+      - name: Run golangci-lint using container-provided config file settings
         run: golangci-lint run -v
 
       # This is the very latest stable version of staticcheck provided by the

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -47,6 +47,17 @@ jobs:
       - name: Install Go linting tools
         run: make lintinstall
 
+      # NOTE: We are intentionally *not* removing the repo-provided config
+      # file (per GH-281) as this workflow is intended to emulate running the
+      # Makefile via a local dev environment.
+      #
+      # - name: Remove repo-provided golangci-lint config file
+      #   run: |
+      #     # Remove the copy of the config file bundled with the repo/code so
+      #     # that the configuration provided by the atc0005/go-ci project is
+      #     # used instead
+      #     rm -vf .golangci.yml
+
       - name: Run Go linting tools using project Makefile
         run: make linting
 

--- a/.github/workflows/lint-and-test-only.yml
+++ b/.github/workflows/lint-and-test-only.yml
@@ -34,7 +34,14 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2.3.1
 
-      - name: Run golangci-lint using repo-provided config file settings
+      - name: Remove repo-provided golangci-lint config file
+        run: |
+          # Remove the copy of the config file bundled with the repo/code so
+          # that the configuration provided by the atc0005/go-ci project is
+          # used instead
+          rm -vf .golangci.yml
+
+      - name: Run golangci-lint using container-provided config file settings
         run: golangci-lint run -v
 
       - name: Run all tests


### PR DESCRIPTION
Remove local/repo-provided config file at start of CI run to enable use of default config file provided by `atc0005/go-ci` Docker container. 

I should note that this is a temporary change that is applied to the checked out content only. The original file remains intact within the repo.

refs GH-274, GH-275