### PR TITLE
Fix linting issues from last golangci-lint release

### DIFF
--- a/cmd/elbow/main.go
+++ b/cmd/elbow/main.go
@@ -122,7 +122,7 @@ func main() {
 					"ignore_errors": appConfig.GetIgnoreErrors(),
 				}).Warn("Error encountered and option to ignore errors not set. Exiting")
 
-				os.Exit(1)
+				return
 			}
 		}
 
@@ -141,7 +141,7 @@ func main() {
 				log.WithFields(logrus.Fields{
 					"ignore_errors": appConfig.GetIgnoreErrors(),
 				}).Warn("Error encountered and option to ignore errors not set. Exiting")
-				os.Exit(1)
+				return
 			}
 			log.Warn("Error encountered, but continuing as requested.")
 		}
@@ -257,7 +257,7 @@ func main() {
 					"ignore_errors": appConfig.GetIgnoreErrors(),
 					"iteration":     pass,
 				}).Warn("Error encountered and option to ignore errors not set. Exiting")
-				os.Exit(1)
+				return
 			}
 			log.Warn("Error encountered, but continuing as requested.")
 			continue

--- a/config/config.go
+++ b/config/config.go
@@ -432,12 +432,12 @@ func (c Config) Version() string {
 	versionString := fmt.Sprintf("%s %s\n%s",
 		strings.ToTitle(c.GetAppName()), c.GetAppVersion(), c.GetAppURL())
 
-	//divider := strings.Repeat("-", len(versionString))
+	// divider := strings.Repeat("-", len(versionString))
 
 	// versionBlock := fmt.Sprintf("\n%s\n%s\n%s\n",
 	// 	divider, versionString, divider)
 
-	//return versionBlock
+	// return versionBlock
 
 	return "\n" + versionString + "\n"
 }

--- a/config/get.go
+++ b/config/get.go
@@ -207,11 +207,11 @@ func (c *Config) GetConfigFile() string {
 // otherwise
 func (c *Config) GetLogger() *logrus.Logger {
 	if c == nil || c.logger == nil {
-		//return nil
+		// return nil
 
 		// FIXME: Is this the best logic?
 		c.logger = logrus.New()
-		//c.logger.Out = os.Stderr
+		// c.logger.Out = os.Stderr
 
 	}
 	return c.logger

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -125,7 +125,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("FilePattern set to nil", func(t *testing.T) {
 		tmpFilePattern := c.FilePattern
-		//t.Logf("c.FilePattern before setting to nil: %p", c.FilePattern)
+		// t.Logf("c.FilePattern before setting to nil: %p", c.FilePattern)
 		c.FilePattern = nil
 		if err := c.Validate(); err == nil {
 			t.Errorf("Config passed, but should have failed on nil FilePattern: %s", err)
@@ -134,7 +134,7 @@ func TestValidate(t *testing.T) {
 		}
 		// Set back to prior value
 		c.FilePattern = tmpFilePattern
-		//t.Logf("c.FilePattern address after resetting back to original value: %p", c.FilePattern)
+		// t.Logf("c.FilePattern address after resetting back to original value: %p", c.FilePattern)
 
 		if err := c.Validate(); err != nil {
 			t.Errorf("Validation failed for config after restoring FilePattern: %s", err)

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -17,7 +17,7 @@
 package logging
 
 import (
-	//"io/ioutil"
+	// "io/ioutil"
 	"fmt"
 	"testing"
 
@@ -43,20 +43,20 @@ func TestLogBufferFlushShouldSucceed(t *testing.T) {
 
 	logger := logrus.New()
 	// Configure logger to throw everything away
-	//logger.SetOutput(ioutil.Discard)
+	// logger.SetOutput(ioutil.Discard)
 	logger.SetLevel(logrus.TraceLevel)
 
 	type test struct {
 		entryLevel logrus.Level
 		// potentially used for dealing with PanicLevel and FatalLevel?
-		//result     error
+		// result     error
 	}
 
 	tests := []test{
 		// TODO: Need to add coverage for messages at these log levels:
 		//
-		//{entryLevel: logrus.PanicLevel, result: nil},
-		//{entryLevel: logrus.FatalLevel, result: nil},
+		// {entryLevel: logrus.PanicLevel, result: nil},
+		// {entryLevel: logrus.FatalLevel, result: nil},
 		//
 		// Problem: Flushing either of these types results in that immediate
 		// action; FatalLevel forces an exit, PanicLevel forces a panic.


### PR DESCRIPTION
- comment formatting
- exitAfterDefer: os.Exit clutters defer

Useful fixes.