### PR TITLE
Fix checksum generation: use unqualified paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,8 +172,9 @@ windows:
 	@env GOOS=windows GOARCH=amd64 $(BUILDCMD) -o $(OUTPUTDIR)/$(APPNAME)/$(APPNAME)-$(VERSION)-windows-amd64.exe ${PWD}/cmd/$(APPNAME)
 
 	@echo "Generating checksum files"
-	@$(CHECKSUMCMD) $(OUTPUTDIR)/$(APPNAME)/$(APPNAME)-$(VERSION)-windows-386.exe > $(OUTPUTDIR)/$(APPNAME)/$(APPNAME)-$(VERSION)-windows-386.exe.sha256
-	@$(CHECKSUMCMD) $(OUTPUTDIR)/$(APPNAME)/$(APPNAME)-$(VERSION)-windows-amd64.exe > $(OUTPUTDIR)/$(APPNAME)/$(APPNAME)-$(VERSION)-windows-amd64.exe.sha256
+	@cd $(OUTPUTDIR)/$(APPNAME) && \
+	$(CHECKSUMCMD) $(APPNAME)-$(VERSION)-windows-386.exe > $(APPNAME)-$(VERSION)-windows-386.exe.sha256 && \
+	$(CHECKSUMCMD) $(APPNAME)-$(VERSION)-windows-amd64.exe > $(APPNAME)-$(VERSION)-windows-amd64.exe.sha256
 
 	@echo "Completed build tasks for windows"
 
@@ -191,7 +192,8 @@ linux:
 	@env GOOS=linux GOARCH=amd64 $(BUILDCMD) -o $(OUTPUTDIR)/$(APPNAME)/$(APPNAME)-$(VERSION)-linux-amd64 ${PWD}/cmd/$(APPNAME)
 
 	@echo "Generating checksum files"
-	@$(CHECKSUMCMD) "$(OUTPUTDIR)/$(APPNAME)/$(APPNAME)-$(VERSION)-linux-386" > "$(OUTPUTDIR)/$(APPNAME)/$(APPNAME)-$(VERSION)-linux-386.sha256"
-	@$(CHECKSUMCMD) "$(OUTPUTDIR)/$(APPNAME)/$(APPNAME)-$(VERSION)-linux-amd64" > "$(OUTPUTDIR)/$(APPNAME)/$(APPNAME)-$(VERSION)-linux-amd64.sha256"
+	@cd $(OUTPUTDIR)/$(APPNAME) && \
+	$(CHECKSUMCMD) "$(APPNAME)-$(VERSION)-linux-386" > "$(APPNAME)-$(VERSION)-linux-386.sha256" && \
+	$(CHECKSUMCMD) "$(APPNAME)-$(VERSION)-linux-amd64" > "$(APPNAME)-$(VERSION)-linux-amd64.sha256"
 
 	@echo "Completed build tasks for linux"


### PR DESCRIPTION
Modify Makefile so that checksums are generated without the full path to the binary. This should allow using checksum verification directly from within the same directory as the binaries.

fixes GH-290