### PR TITLE
Prune unnecessary newline escape character

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -172,7 +172,7 @@ func NewConfig(appVersion string) (*Config, error) {
 
 	logging.Buffer.Add(logging.LogRecord{
 		Level:   logrus.DebugLevel,
-		Message: fmt.Sprintf("Current baseConfig after NewDefaultConfig() call: %+v\n", baseConfig),
+		Message: fmt.Sprintf("Current baseConfig after NewDefaultConfig() call: %+v", baseConfig),
 		Fields:  logrus.Fields{"line": logging.GetLineNumber()},
 	})
 
@@ -205,7 +205,7 @@ func NewConfig(appVersion string) (*Config, error) {
 
 	logging.Buffer.Add(logging.LogRecord{
 		Level:   logrus.DebugLevel,
-		Message: fmt.Sprintf("Current argsConfig after MustParse() call: %+v\n", argsConfig),
+		Message: fmt.Sprintf("Current argsConfig after MustParse() call: %+v", argsConfig),
 		Fields:  logrus.Fields{"line": logging.GetLineNumber()},
 	})
 
@@ -270,7 +270,7 @@ func NewConfig(appVersion string) (*Config, error) {
 
 		logging.Buffer.Add(logging.LogRecord{
 			Level:   logrus.DebugLevel,
-			Message: fmt.Sprintf("Current fileConfig after LoadConfigFile() call: %+v\n", fileConfig),
+			Message: fmt.Sprintf("Current fileConfig after LoadConfigFile() call: %+v", fileConfig),
 			Fields:  logrus.Fields{"line": logging.GetLineNumber()},
 		})
 

--- a/config/logger.go
+++ b/config/logger.go
@@ -37,13 +37,13 @@ func (c *Config) SetLoggerConfig() error {
 
 	logging.Buffer.Add(logging.LogRecord{
 		Level:   logrus.DebugLevel,
-		Message: fmt.Sprintf("Current state of config object: %+v\n", c),
+		Message: fmt.Sprintf("Current state of config object: %+v", c),
 		Fields:  logrus.Fields{"line": logging.GetLineNumber()},
 	})
 
 	logging.Buffer.Add(logging.LogRecord{
 		Level:   logrus.DebugLevel,
-		Message: fmt.Sprintf("The address of the logger SetLoggerConfig received: %p\n", c.GetLogger()),
+		Message: fmt.Sprintf("The address of the logger SetLoggerConfig received: %p", c.GetLogger()),
 		Fields:  logrus.Fields{"line": logging.GetLineNumber()},
 	})
 
@@ -60,7 +60,7 @@ func (c *Config) SetLoggerConfig() error {
 
 	logging.Buffer.Add(logging.LogRecord{
 		Level:   logrus.DebugLevel,
-		Message: fmt.Sprintf("logger.Out field at start of SetLoggerFormatter(): %p\n", c.GetLogger().Out),
+		Message: fmt.Sprintf("logger.Out field at start of SetLoggerFormatter(): %p", c.GetLogger().Out),
 		Fields: logrus.Fields{
 			"line": logging.GetLineNumber(),
 		},
@@ -72,7 +72,7 @@ func (c *Config) SetLoggerConfig() error {
 
 	logging.Buffer.Add(logging.LogRecord{
 		Level:   logrus.DebugLevel,
-		Message: fmt.Sprintf("logger.Out field after SetLoggerFormatter: %p\n", c.GetLogger().Out),
+		Message: fmt.Sprintf("logger.Out field after SetLoggerFormatter: %p", c.GetLogger().Out),
 		Fields: logrus.Fields{
 			"line": logging.GetLineNumber(),
 		},
@@ -84,7 +84,7 @@ func (c *Config) SetLoggerConfig() error {
 
 	logging.Buffer.Add(logging.LogRecord{
 		Level:   logrus.DebugLevel,
-		Message: fmt.Sprintf("logger.Out field after SetLoggerConsoleOutput(): %p\n", c.GetLogger().Out),
+		Message: fmt.Sprintf("logger.Out field after SetLoggerConsoleOutput(): %p", c.GetLogger().Out),
 		Fields: logrus.Fields{
 			"line": logging.GetLineNumber(),
 		},
@@ -167,9 +167,9 @@ func (c *Config) SetLoggerConfig() error {
 		Level:   logrus.DebugLevel,
 		Message: "logging object details at end of SetLoggerConfig()",
 		Fields: logrus.Fields{
-			"logger": fmt.Sprintf("%+v\n", c.GetLogger()),
+			"logger": fmt.Sprintf("%+v", c.GetLogger()),
 			// TODO: Re-evaluate potential for field ref on nil pointer
-			"logger_out": fmt.Sprintf("%+v\n", c.GetLogger().Out),
+			"logger_out": fmt.Sprintf("%+v", c.GetLogger().Out),
 			"line":       logging.GetLineNumber(),
 		},
 	})

--- a/config/merge_complete_configs_test.go
+++ b/config/merge_complete_configs_test.go
@@ -263,7 +263,7 @@ func TestMergeConfigUsingCompleteConfigObjects(t *testing.T) {
 
 	// Unset environment variables that we just set
 	for _, table := range envVarTables {
-		t.Logf("Unsetting %q\n", table.envVar)
+		t.Logf("Unsetting %q", table.envVar)
 		if err := os.Unsetenv(table.envVar); err != nil {
 			t.Errorf("Unable to unset environment variable: %v", err)
 

--- a/config/merge_incomplete_configs_test.go
+++ b/config/merge_incomplete_configs_test.go
@@ -348,7 +348,7 @@ func TestMergeConfigUsingIncompleteConfigObjects(t *testing.T) {
 
 	// Unset environment variables that we just set
 	for _, table := range envVarTables {
-		t.Logf("Unsetting %q\n", table.envVar)
+		t.Logf("Unsetting %q", table.envVar)
 		if err := os.Unsetenv(table.envVar); err != nil {
 			t.Errorf("Unable to unset environment variable: %v", err)
 

--- a/matches/matches.go
+++ b/matches/matches.go
@@ -79,12 +79,12 @@ func HasMatchingExtension(filename string, config *config.Config) bool {
 
 	if len(config.GetFileExtensions()) == 0 {
 		log.Debug("No extension limits have been set!")
-		log.Debugf("Considering %s safe for removal\n", filename)
+		log.Debugf("Considering %s safe for removal", filename)
 		return true
 	}
 
 	if InList(ext, config.GetFileExtensions()) {
-		log.Debugf("%s has a valid extension for removal\n", filename)
+		log.Debugf("%s has a valid extension for removal", filename)
 		return true
 	}
 
@@ -102,7 +102,7 @@ func HasMatchingFilenamePattern(filename string, config *config.Config) bool {
 
 	if strings.TrimSpace(config.GetFilePattern()) == "" {
 		log.Debug("No FilePattern has been specified!")
-		log.Debugf("Considering %s safe for removal\n", filename)
+		log.Debugf("Considering %s safe for removal", filename)
 		return true
 	}
 


### PR DESCRIPTION
Remove newline escape character from log messages where it ends up showing as a literal value in log output.

fixes GH-315