### PR TITLE
Fix ST1023 linting error

### DIFF
--- a/cmd/elbow/main.go
+++ b/cmd/elbow/main.go
@@ -94,7 +94,7 @@ func main() {
 	var appResults paths.ProcessingResults
 
 	var pass int
-	var totalPaths int = len(appConfig.GetPaths())
+	var totalPaths = len(appConfig.GetPaths())
 	for _, path := range appConfig.GetPaths() {
 
 		pass++


### PR DESCRIPTION
As noted:

"ST1023: should omit type int from declaration; it will be
inferred from the right-hand side (stylecheck)"

fixes GH-333