### PR TITLE
Lock Go version to the latest "oldstable" series

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,3 +85,10 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "canary"
+    ignore:
+      - dependency-name: "golang"
+        versions:
+          # Ignore updates from series associated with the latest "stable"
+          # Go release and no longer supported Go versions.
+          - ">= 1.17"
+          - "< 1.16"


### PR DESCRIPTION
Hold back from using the latest Go version until sufficient
testing has been performed.