### PR TITLE
Update build tags for Go 1.17 compatibility

### DIFF
--- a/logging/logging_unix.go
+++ b/logging/logging_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Copyright 2020 Adam Chalkley

--- a/logging/logging_windows.go
+++ b/logging/logging_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Copyright 2020 Adam Chalkley


### PR DESCRIPTION
golangci-lint v1.42.1 introduced changes to the `gofmt` linter.
These changes appear to match the same ones introduced with
Go 1.17 which expect build tags to be in a specific format
OR include an additional leading set of build tags with
the `//go:` prefix.

This commit adds this additional build tag entry to both
os-specific variants of the `logging_*.go` file.

fixes GH-350