### PR TITLE
Ignore false-positive gosec G307 linting errors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -231,6 +231,10 @@ func NewConfig(appVersion string) (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to open config file: %v", err)
 		}
+
+		// #nosec G307
+		// Believed to be a false-positive from recent gosec release
+		// https://github.com/securego/gosec/issues/714
 		defer func() {
 			if err := fh.Close(); err != nil {
 				// Ignore "file already closed" errors

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -207,6 +207,10 @@ func TestLoadConfigFileTemplate(t *testing.T) {
 		} else {
 			t.Log("Successfully opened config file", exampleConfigFile)
 		}
+
+		// #nosec G307
+		// Believed to be a false-positive from recent gosec release
+		// https://github.com/securego/gosec/issues/714
 		defer func() {
 			if err := fh.Close(); err != nil {
 				// Ignore "file already closed" errors


### PR DESCRIPTION
Issues reported after upgrading golangci-lint to v1.43.0.
gosec was updated in that version from v2.8.1 to v2.9.1.

fixes atc0005/elbow#362
refs golangci/golangci-lint#2299