### PR TITLE
Apply linting fixes for Go 1.19 release

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -418,7 +417,7 @@ func NewConfig(appVersion string) (*Config, error) {
 // in TOML format into the associated Config struct.
 func (c *Config) LoadConfigFile(fileHandle io.Reader) error {
 
-	configFile, err := ioutil.ReadAll(fileHandle)
+	configFile, err := io.ReadAll(fileHandle)
 	if err != nil {
 		return err
 	}

--- a/config/get.go
+++ b/config/get.go
@@ -77,7 +77,6 @@ func (c *Config) GetFilePattern() string {
 // As an example, the https://github.com/google/go-github package has a
 // `Issue.GetAssignees()` method that returns nil if the `Issue.Assignees`
 // field is nil. This seems to suggest that this is all we really can do here?
-//
 func (c *Config) GetFileExtensions() []string {
 	if c == nil || c.FileExtensions == nil {
 		// FIXME: Isn't the goal to avoid returning nil?

--- a/doc.go
+++ b/doc.go
@@ -1,96 +1,48 @@
 /*
-
 Elbow prunes content matching specific patterns, either in a single
 directory or recursively through a directory tree.
 
-PROJECT HOME
+# Project Home
 
 See our GitHub repo (https://github.com/atc0005/elbow) for the latest code, to
 file an issue or submit improvements for review and potential inclusion into
 the project.
 
-PURPOSE
+# Purpose
 
 Prune content matching specific patterns, either in a single directory or
 recursively through a directory tree. The primary goal is to use this
 application from a cron job to perform routine pruning of generated files that
 would otherwise completely clog a filesystem.
 
-GOTCHAS
+# Gotchas
 
-• File extensions are case-sensitive.
+  - File extensions are case-sensitive.
+  - File name patterns are case-sensitive.
+  - File name patterns, much like shell globs, may match more than intended. Test carefully and do not enable file removal until you have tested and are ready to actually prune the content.
 
-• File name patterns are case-sensitive.
+# Features
 
-• File name patterns, much like shell globs, may match more than intended. Test carefully and do not enable file removal until you have tested and are ready to actually prune the content.
+  - Supports multiple (merged) sources for supplying configuration settings
+    Default settings
+    TOML format configuration file
+    Environment variables
+    Command-line flags (with detailed help output)
+  - Match on specified file patterns
+  - Flat (single-level) or recursive search
+  - Process one or many paths
+  - Age-based threshold for matches (e.g., match files X days old or older)
+  - Keep a specified number of older or newer matches
+  - Limit search to specified list of file extensions
+  - Toggle file removal (read-only by default)
+  - Extensive, leveled-logging
+  - (Optional) Syslog logging (not supported on Windows)
+  - (Optional) Logging to a file (if enabled, mutes console output)
+  - Logging in Text or JSON log formats
+  - (Optional) Ignore errors encountered when removing files
 
-FEATURES
+# Usage
 
-• Supports multiple (merged) sources for supplying configuration settings
-  Default settings
-  TOML format configuration file
-  Environment variables
-  Command-line flags (with detailed help output)
-
-• Match on specified file patterns
-
-• Flat (single-level) or recursive search
-
-• Process one or many paths
-
-• Age-based threshold for matches (e.g., match files X days old or older)
-
-• Keep a specified number of older or newer matches
-
-• Limit search to specified list of file extensions
-
-• Toggle file removal (read-only by default)
-
-• Extensive, leveled-logging
-
-• (Optional) Syslog logging (not supported on Windows)
-
-• (Optional) Logging to a file (if enabled, mutes console output)
-
-• Logging in Text or JSON log formats
-
-• (Optional) Ignore errors encountered when removing files
-
-USAGE
-
-Help output is below. See the README for examples.
-
-   $ ./elbow --help
-   Elbow prunes content matching specific patterns, either in a single directory or recursively through a directory tree.
-
-   ELBOW x.y.z
-   https://github.com/atc0005/elbow
-
-   Usage: elbow [--pattern PATTERN] [--extensions EXTENSIONS] [--age AGE] [--keep KEEP] [--keep-old] [--remove] [--ignore-errors] [--log-level LOG-LEVEL] [--log-format LOG-FORMAT] [--log-file LOG-FILE] [--console-output CONSOLE-OUTPUT] [--use-syslog] [--paths PATHS] [--recurse] [--config-file CONFIG-FILE]
-
-   Options:
-   --pattern PATTERN      Substring pattern to compare filenames against. Wildcards are not supported.
-   --extensions EXTENSIONS
-                           Limit search to specified file extensions. Specify as space separated list to match multiple required extensions.
-   --age AGE              Limit search to files that are the specified number of days old or older.
-   --keep KEEP            Keep specified number of matching files per provided path. [default: -1]
-   --keep-old             Keep oldest files instead of newer per provided path.
-   --remove               Remove matched files per provided path.
-   --ignore-errors        Ignore errors encountered during file removal.
-   --log-level LOG-LEVEL
-                           Maximum log level at which messages will be logged. Log messages below this threshold will be discarded. [default: info]
-   --log-format LOG-FORMAT
-                           Log formatter used by logging package. [default: text]
-   --log-file LOG-FILE    Optional log file used to hold logged messages. If set, log messages are not displayed on the console.
-   --console-output CONSOLE-OUTPUT
-                           Specify how log messages are logged to the console. [default: stdout]
-   --use-syslog           Log messages to syslog in addition to other outputs. Not supported on Windows.
-   --paths PATHS          List of comma or space-separated paths to process.
-   --recurse              Perform recursive search into subdirectories per provided path.
-   --config-file CONFIG-FILE
-                           Full path to optional TOML-formatted configuration file. See config.example.toml for a starter template.
-   --help, -h             display this help and exit
-   --version              display version and exit
-
+See our main README for supported settings and examples.
 */
 package main

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -17,7 +17,7 @@
 package logging
 
 import (
-	// "io/ioutil"
+	// "io"
 	"fmt"
 	"testing"
 
@@ -43,7 +43,7 @@ func TestLogBufferFlushShouldSucceed(t *testing.T) {
 
 	logger := logrus.New()
 	// Configure logger to throw everything away
-	// logger.SetOutput(ioutil.Discard)
+	// logger.SetOutput(io.Discard)
 	logger.SetLevel(logrus.TraceLevel)
 
 	type test struct {


### PR DESCRIPTION
- Go doc comment formatting fixes
- Swap io/ioutil package for io package
  - including updates to handle change from working with
    []fs.FileInfo type to []os.DirEntry type