### PR TITLE
Fix various revive linting errors

### DIFF
--- a/cmd/elbow/main.go
+++ b/cmd/elbow/main.go
@@ -139,7 +139,6 @@ func main() {
 				log.WithFields(logrus.Fields{
 					"ignore_errors": appConfig.GetIgnoreErrors(),
 				}).Warn("Error encountered, but continuing as requested.")
-				continue
 			} else {
 				log.WithFields(logrus.Fields{
 					"ignore_errors": appConfig.GetIgnoreErrors(),

--- a/config/config.go
+++ b/config/config.go
@@ -416,17 +416,12 @@ func NewConfig(appVersion string) (*Config, error) {
 // LoadConfigFile reads from an io.Reader and unmarshals a configuration file
 // in TOML format into the associated Config struct.
 func (c *Config) LoadConfigFile(fileHandle io.Reader) error {
-
 	configFile, err := io.ReadAll(fileHandle)
 	if err != nil {
 		return err
 	}
 
-	if err := toml.Unmarshal(configFile, c); err != nil {
-		return err
-	}
-
-	return nil
+	return toml.Unmarshal(configFile, c)
 }
 
 // Description provides an overview as part of the application Help output

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func GetBaseProjectDir(t *testing.T) string {
+	t.Helper()
 
 	// https://stackoverflow.com/questions/23847003/golang-tests-and-working-directory
 	// TODO: How else to retrieve only the one value that I need? See GH-237.

--- a/logging/logging_windows.go
+++ b/logging/logging_windows.go
@@ -25,7 +25,7 @@ import (
 
 // EnableSyslogLogging attempts to enable local syslog logging for non-Windows
 // systems. For Windows systems the attempt is skipped.
-func EnableSyslogLogging(logger *logrus.Logger, logBuffer *LogBuffer, logLevel string) error {
+func EnableSyslogLogging(_ *logrus.Logger, logBuffer *LogBuffer, _ string) error {
 
 	logBuffer.Add(LogRecord{
 		// TODO: Not sure what log level is appropriate here. We are already


### PR DESCRIPTION
Resolve issues identified by the revive linter from golangci-lint version v1.52.2.