### PR TITLE
Update Dependabot PR prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,7 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "go.mod"
+      prefix: "Go Dependency"
 
   - package-ecosystem: "gomod"
     directory: "/"
@@ -54,7 +54,7 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "go.mod"
+      prefix: "Go Dependency"
 
   ######################################################################
   # Monitor GitHub Actions dependency updates
@@ -116,7 +116,7 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "canary"
+      prefix: "Go Runtime"
     ignore:
       - dependency-name: "golang"
         versions:
@@ -139,7 +139,7 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "canary"
+      prefix: "Go Runtime"
 
   ######################################################################
   # Monitor images used to build project releases
@@ -161,7 +161,7 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "docker"
+      prefix: "Build Image"
 
   - package-ecosystem: docker
     directory: "/dependabot/docker/builds"
@@ -179,4 +179,4 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "docker"
+      prefix: "Build Image"


### PR DESCRIPTION
Swap out current prefixes for ones which provide more specific context
for what the update covers.

- replace `go.mod` with `Go Dependency`
- replace `canary` with `Go Runtime`
- replace `docker` with `Build Image`

Refs:

- atc0005/todo#72