### PR TITLE
Add todo/release label to "Go Runtime" PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -113,6 +113,7 @@ updates:
     labels:
       - "dependencies"
       - "CI"
+      - "todo/release"
     allow:
       - dependency-type: "all"
     commit-message:
@@ -136,6 +137,7 @@ updates:
     labels:
       - "dependencies"
       - "CI"
+      - "todo/release"
     allow:
       - dependency-type: "all"
     commit-message:


### PR DESCRIPTION
This label is intended to provide a "hook" for Dependabot generated
"Go Runtime" PRs for later automation purposes.
