### PR TITLE
Update project to Go 1.22 series

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -121,8 +121,8 @@ updates:
     ignore:
       - dependency-name: "golang"
         versions:
-          - ">= 1.22"
-          - "< 1.21"
+          - ">= 1.23.0"
+          - "< 1.22.0"
 
   - package-ecosystem: docker
     directory: "/dependabot/docker/go"


### PR DESCRIPTION
Update Dependabot configuration for Dockerfile to ignore Go releases
outside of the Go 1.22 release series.

We update previous match syntax to use x.y.Z syntax (vs just x.Y)
in an effort to exclude future offerings of Go RC versions as a
stable update.

NOTE:

We intentionally do *not* update the Go module version; bumping
the Go module version would indicate that this project *requires* a
newer Go version for functionality provided by that version (and that
is not yet the case).
