### PR TITLE
Disable Dependabot automatic PR rebasing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,38 +16,51 @@
 
 # https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
 
+######################################################################
+# Monitor Go module dependency updates
+######################################################################
+
 version: 2
 updates:
-  # Enable version updates for Go modules
   - package-ecosystem: "gomod"
-
-    # Look for a `go.mod` file in the `root` directory
     directory: "/"
-
-    # Default is a maximum of five pull requests for version updates
     open-pull-requests-limit: 10
-
     target-branch: "master"
-
-    # Daily update checks; default version checks are performed at 05:00 UTC
     schedule:
       interval: "daily"
       time: "02:00"
       timezone: "America/Chicago"
-
-    # Assign everything to me by default
     assignees:
       - "atc0005"
     labels:
       - "dependencies"
-
     allow:
-      # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
-
     commit-message:
-      # Prefix all commit messages with "go.mod"
-      prefix: "go.mod"
+      prefix: "Go Dependency"
+    rebase-strategy: "disabled"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    open-pull-requests-limit: 10
+    target-branch: "development"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "Go Dependency"
+    rebase-strategy: "disabled"
+
+  ######################################################################
+  # Monitor GitHub Actions dependency updates
+  ######################################################################
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -65,9 +78,32 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "ghaw"
+      prefix: "CI Dependency"
+    rebase-strategy: "disabled"
 
-  # Monitor Go updates to serve as a reminder to generate fresh binaries
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 10
+    target-branch: "development"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "CI"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "CI Dependency"
+    rebase-strategy: "disabled"
+
+  ######################################################################
+  # Monitor Go updates to service as a reminder to generate new releases
+  ######################################################################
+
   - package-ecosystem: docker
     directory: "/dependabot/docker/go"
     open-pull-requests-limit: 10
@@ -81,19 +117,42 @@ updates:
     labels:
       - "dependencies"
       - "CI"
+      - "todo/release"
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "canary"
+      prefix: "Go Runtime"
+    rebase-strategy: "disabled"
     ignore:
       - dependency-name: "golang"
         versions:
-          # Ignore updates from series associated with the latest "stable"
-          # Go release and no longer supported Go versions.
-          - ">= 1.20"
-          - "< 1.19"
+          - ">= 1.24.0"
+          - "< 1.23.0"
 
-  # Monitor image used to build dev & stable project releases
+  - package-ecosystem: docker
+    directory: "/dependabot/docker/go"
+    open-pull-requests-limit: 10
+    target-branch: "development"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "CI"
+      - "todo/release"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "Go Runtime"
+    rebase-strategy: "disabled"
+
+  ######################################################################
+  # Monitor images used to build project releases
+  ######################################################################
+
   - package-ecosystem: docker
     directory: "/dependabot/docker/builds"
     open-pull-requests-limit: 10
@@ -110,4 +169,24 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "docker"
+      prefix: "Build Image"
+    rebase-strategy: "disabled"
+
+  - package-ecosystem: docker
+    directory: "/dependabot/docker/builds"
+    open-pull-requests-limit: 10
+    target-branch: "development"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "builds"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "Build Image"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Update the .github/dependabot.yml`` file to include the
`rebase-strategy: "disabled"` setting for each update configuration.

This change is intended to disable automatic rebasing for all open PRs
and instead put that control/timing in the hands of the project
maintainer who can selectively enable rebasing as needed. This is
intended to prevent Dependabot from flooding project queues with
pending/active CI jobs resulting in PRs that a maintainer is actively
working on being held up waiting for their turn to run.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
